### PR TITLE
Respond with 404 not 500 when a Dynasnip is accessed directly

### DIFF
--- a/soups/dynasnips/by.snip.rb
+++ b/soups/dynasnips/by.snip.rb
@@ -1,7 +1,12 @@
 class By < Dynasnip
-  def handle(person)
-    initials = person.split("-").map(&:first).join
-    "<em>&mdash; {l #{person}, #{initials.upcase}}</em>"
+  def handle(person=nil)
+    if person
+      initials = person.split("-").map(&:first).join
+      "<em>&mdash; {l #{person}, #{initials.upcase}}</em>"
+    else
+      app.response.status = 404
+      %{Not found}
+    end
   end
 
   self

--- a/soups/dynasnips/list-of.rb
+++ b/soups/dynasnips/list-of.rb
@@ -1,24 +1,28 @@
 require 'vanilla/dynasnip'
 
 class ListOf < Dynasnip
-  def handle(options)
+  def handle(options={})
     options = {:element => 'ul'}.merge(options)
 
-    kind = options[:kind]
-    limit = options[:limit]
-    el = options[:element]
+    if kind = options[:kind]
+      limit = options[:limit]
+      el = options[:element]
 
-    entries = soup[:kind => kind].sort_by { |e| e.created_at }.reverse
-    entries = entries[0..limit.to_i] unless limit == nil
+      entries = soup[:kind => kind].sort_by { |e| e.created_at }.reverse
+      entries = entries[0..limit.to_i] unless limit == nil
 
-    value = entries.length + 1
+      value = entries.length + 1
 
-    "<#{el} class='" + kind + "_list' reversed>" + entries.map do |entry|
-      title = entry.content.split("\n").first
-      url = url_to(entry.name)
-      value -= 1
-      %{<li value="#{value}"><a href="#{url}">#{title}</a></li>}
-    end.join + "</#{el}>"
+      "<#{el} class='" + kind + "_list' reversed>" + entries.map do |entry|
+        title = entry.content.split("\n").first
+        url = url_to(entry.name)
+        value -= 1
+        %{<li value="#{value}"><a href="#{url}">#{title}</a></li>}
+      end.join + "</#{el}>"
+    else
+      app.response.status = 404
+      %{Not found}
+    end
   end
   self
 end

--- a/soups/dynasnips/member.rb
+++ b/soups/dynasnips/member.rb
@@ -1,15 +1,20 @@
 require 'vanilla/dynasnip'
 
 class Member < Dynasnip
-  def handle(name)
-    member = app.soup[name]
-    template = app.soup["member"].template
-    # TODO: produce hCard?
-    template.gsub("NAME", member.name.split("-").map { |s| s.capitalize }.join(" ")).
-             gsub("SITE", member.site).
-             gsub("TWITTER", member.twitter).
-             gsub("IMAGE", member.image).
-             gsub("CONTENT", app.render(member))
+  def handle(name=nil)
+    if name
+      member = app.soup[name]
+      template = app.soup["member"].template
+      # TODO: produce hCard?
+      template.gsub("NAME", member.name.split("-").map { |s| s.capitalize }.join(" ")).
+               gsub("SITE", member.site).
+               gsub("TWITTER", member.twitter).
+               gsub("IMAGE", member.image).
+               gsub("CONTENT", app.render(member))
+    else
+      app.response.status = 404
+      %{Not found}
+    end
   end
   self
 end

--- a/soups/dynasnips/project.rb
+++ b/soups/dynasnips/project.rb
@@ -1,22 +1,26 @@
 require 'vanilla/dynasnip'
 
 class Project < Dynasnip
-  def handle(name)
-    piece = app.soup[name]
-    template = app.soup["project"].template
+  def handle(name=nil)
+    if name
+      piece = app.soup[name]
+      template = app.soup["project"].template
 
-    if piece.images
-      images_html = piece.images.map do |image_url|
-        %{<li><img src="/images/folio/#{image_url}" /></li>}
-      end.join
+      if piece.images
+        images_html = piece.images.map do |image_url|
+          %{<li><img src="/images/folio/#{image_url}" /></li>}
+        end.join
+      else
+        images_html = ""
+      end
+
+      template.gsub("NAME", piece.display_name).
+               gsub("IMAGES", images_html).
+               gsub("CONTENT", app.render(piece))
     else
-      images_html = ""
+      app.response.status = 404
+      %{Not found}
     end
-
-    template.gsub("NAME", piece.display_name).
-             gsub("IMAGES", images_html).
-             gsub("CONTENT", app.render(piece))
-
   end
   self
 end


### PR DESCRIPTION
It's possible to generate 500 errors by hitting e.g.
http://gofreerange.com/member. This seems undesirable, not least
because it generates an exception notification email.

The exception we were seeing was:

```
ArgumentError: wrong number of arguments (0 for 1)

vendor/gems/ruby/1.8/bundler/gems/vanilla-rb-586acf13dd8f/lib/vanilla/renderers/ruby.rb:35:in `handle'
vendor/gems/ruby/1.8/bundler/gems/vanilla-rb-586acf13dd8f/lib/vanilla/renderers/ruby.rb:35:in `send'
vendor/gems/ruby/1.8/bundler/gems/vanilla-rb-586acf13dd8f/lib/vanilla/renderers/ruby.rb:35:in `process_text'
vendor/gems/ruby/1.8/bundler/gems/vanilla-rb-586acf13dd8f/lib/vanilla/renderers/base.rb:99:in `render_without_including_snips'
vendor/gems/ruby/1.8/bundler/gems/vanilla-rb-586acf13dd8f/lib/vanilla/renderers/base.rb:87:in `render'
vendor/gems/ruby/1.8/bundler/gems/vanilla-rb-586acf13dd8f/lib/vanilla/app.rb:70:in `render'
```

A better fix might be to make these snips not directly routable,
but I think that would involve changes to Vanilla, so I've avoided
that for now. Also I'm not sure if some of them _need_ to be directly
