### PR TITLE
Add FutureLearn to work snip

### DIFF
--- a/soups/projects/futurelearn.snip.markdown
+++ b/soups/projects/futurelearn.snip.markdown
@@ -1,0 +1,12 @@
+We worked with [FutureLearn][] to help build the first UK platform for [MOOC][]s.
+
+We were approached by FutureLearn in April 2013 and were quick to agree to get involved in such an exciting project. We worked with an ever growing team to get the platform ready for the public launch in September, and then on to the uncapped courses that opened in January 2014.
+
+We think it's a great project, with a great team, and we're proud to have been involved.
+
+[FutureLearn]: https://www.futurelearn.com/
+[MOOC]: http://en.wikipedia.org/wiki/Massive_open_online_course
+
+:kind: project
+:display_name: "FutureLearn"
+:url: https://www.futurelearn.com/

--- a/soups/work.snip
+++ b/soups/work.snip
@@ -3,6 +3,9 @@
 
   <ol id="project-list">
     <li>
+      {project futurelearn}
+    </li>
+    <li>
       {project harmonia}
     </li>
     <li>


### PR DESCRIPTION
This will appear at the top of our list of recent work on the homepage
and at /work.
