### PR TITLE
Disable telephone number detection on iOS

### DIFF
--- a/soups/layout.snip
+++ b/soups/layout.snip
@@ -15,6 +15,7 @@
   <meta keywords="ruby rails software development london" />
   <meta name="google-site-verification" content="GNqgxou6cYLkYq9l47mZM00R93JN49KqRhJebklH7uo" />
   <meta content='width=device-width' name='viewport'>
+  <meta name='format-detection' content='telephone=no'>
   <meta content='chrome=1' http-equiv='X-UA-Compatible'>
 </head>
 <body class="{body_class}">


### PR DESCRIPTION
By default, Safari on iOS tries to automatically detect any phone numbers in the page to make them clickable. Unfortunately, this behaviour is triggered by the company number (06789592) in the footer of every page.

The format-detection meta tag disables this behaviour:

https://developer.apple.com/library/ios/featuredarticles/iPhoneURLScheme_Reference/PhoneLinks/PhoneLinks.html