### PR TITLE
Rake tasks for weeknotes and weeklinks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,15 +55,16 @@ namespace :week do
     Creates a new weeknotes snip for the current GFR week.
 
     By default it calculates the GFR week number based on today's
-    date, but you can override that by supplying a parseable date
-    in the DATE environment variable.
+    date, but you can override that either by supplying a parseable
+    date in the DATE environment variable or by setting the WEEK
+    environment variable to the GFR week number.
     DESC
     task :create do
       app = Application.new
       snip = app.soup['week-nnn']
 
       date = Date.parse(ENV['DATE']) rescue Date.today
-      week_number = weeks_since_incorporation(date).to_i
+      week_number = (ENV['WEEK'] || weeks_since_incorporation(date)).to_i
       username = `whoami`.chomp
       author = USERNAMES_VS_AUTHORS.fetch(username)
 
@@ -80,8 +81,9 @@ namespace :week do
     Prepares the current weeknotes snip for publication.
 
     By default it calculates the GFR week number based on today's
-    date, but you can override that by supplying a parseable date
-    in the DATE environment variable.
+    date, but you can override that either by supplying a parseable
+    date in the DATE environment variable or by setting the WEEK
+    environment variable to the GFR week number.
 
     If a weeknotes snip for the relevant GFR week does not exist,
     it will exit with an error message.
@@ -90,7 +92,7 @@ namespace :week do
       app = Application.new
 
       date = Date.parse(ENV['DATE']) rescue Date.today
-      week_number = weeks_since_incorporation(date).to_i
+      week_number = (ENV['WEEK'] || weeks_since_incorporation(date)).to_i
       snip_name = "week-#{week_number}"
       snip = app.soup[snip_name]
       unless snip
@@ -109,15 +111,16 @@ namespace :week do
     Creates a new weeklinks snip for the current GFR week.
 
     By default it calculates the GFR week number based on today's
-    date, but you can override that by supplying a parseable date
-    in the DATE environment variable.
+    date, but you can override that either by supplying a parseable
+    date in the DATE environment variable or by setting the WEEK
+    environment variable to the GFR week number.
     DESC
     task :create do
       app = Application.new
       snip = app.soup['week-nnn-links']
 
       date = Date.parse(ENV['DATE']) rescue Date.today
-      week_number = weeks_since_incorporation(date).to_i
+      week_number = (ENV['WEEK'] || weeks_since_incorporation(date)).to_i
       username = `whoami`.chomp
       author = USERNAMES_VS_AUTHORS.fetch(username)
 
@@ -134,8 +137,9 @@ namespace :week do
     Prepares the current weeklinks snip for publication.
 
     By default it calculates the GFR week number based on today's
-    date, but you can override that by supplying a parseable date
-    in the DATE environment variable.
+    date, but you can override that either by supplying a parseable
+    date in the DATE environment variable or by setting the WEEK
+    environment variable to the GFR week number.
 
     If a weeklinks snip for the relevant GFR week does not exist,
     it will exit with an error message.
@@ -144,7 +148,7 @@ namespace :week do
       app = Application.new
 
       date = Date.parse(ENV['DATE']) rescue Date.today
-      week_number = weeks_since_incorporation(date).to_i
+      week_number = (ENV['WEEK'] || weeks_since_incorporation(date)).to_i
       snip_name = "week-#{week_number}-links"
       snip = app.soup[snip_name]
       unless snip

--- a/Rakefile
+++ b/Rakefile
@@ -103,4 +103,31 @@ namespace :week do
       snip.save
     end
   end
+
+  namespace :links do
+    desc <<-DESC
+    Creates a new weeklinks snip for the current GFR week.
+
+    By default it calculates the GFR week number based on today's
+    date, but you can override that by supplying a parseable date
+    in the DATE environment variable.
+    DESC
+    task :create do
+      app = Application.new
+      snip = app.soup['week-nnn-links']
+
+      date = Date.parse(ENV['DATE']) rescue Date.today
+      week_number = weeks_since_incorporation(date).to_i
+      username = `whoami`.chomp
+      author = USERNAMES_VS_AUTHORS.fetch(username)
+
+      snip.author = author
+      snip.created_at = Time.now
+      snip.updated_at = Time.now
+      snip.page_title = "Week #{week_number} - Interesting links"
+      snip.name = "week-#{week_number}-links"
+      snip.content.gsub!(/Week NNN/, "Week #{week_number}")
+      snip.save
+    end
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,20 @@ end
 
 require "date"
 
+def monday_beginning(date)
+  # The `+1` is to deal with `#wday` being 0 based and starting from Sunday
+  date - date.wday + 1
+end
+
+def weeks_since_incorporation(date)
+  # Tuesday 13th Jan 2009
+  incorporation_date = Date.parse('2009-01-13')
+  monday_beginning_the_week_of_incorporation = monday_beginning(incorporation_date)
+  monday_beginning_this_week = monday_beginning(date)
+  days_since_incorporation = monday_beginning_this_week - monday_beginning_the_week_of_incorporation
+  days_since_incorporation / 7.0
+end
+
 desc <<-DESC
 Displays the GFR week number from the date of incorporation.
 
@@ -20,20 +34,7 @@ Example: `GFR_DATE=2014-03-24 rake display_gfr_week_number`
 => Week beginning 24 Mar 2014 is week 271
 DESC
 task :display_gfr_week_number do
-  def monday_beginning(date)
-    # The `+1` is to deal with `#wday` being 0 based and starting from Sunday
-    date - date.wday + 1
-  end
+  date = Date.parse(ENV['GFR_DATE']) rescue Date.today
 
-  # Tuesday 13th Jan 2009
-  incorporation_date = Date.parse('2009-01-13')
-  monday_beginning_the_week_of_incorporation = monday_beginning(incorporation_date)
-
-  today = Date.parse(ENV['GFR_DATE']) rescue Date.today
-  monday_beginning_this_week = monday_beginning(today)
-
-  days_since_incorporation = monday_beginning_this_week - monday_beginning_the_week_of_incorporation
-  weeks_since_incorporation = days_since_incorporation / 7.0
-
-  puts "Week beginning #{monday_beginning_this_week.strftime("%d %b %Y")} is week #{weeks_since_incorporation.to_i}"
+  puts "Week beginning #{monday_beginning(date).strftime("%d %b %Y")} is week #{weeks_since_incorporation(date).to_i}"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -129,5 +129,32 @@ namespace :week do
       snip.content.gsub!(/Week NNN/, "Week #{week_number}")
       snip.save
     end
+
+    desc <<-DESC
+    Prepares the current weeklinks snip for publication.
+
+    By default it calculates the GFR week number based on today's
+    date, but you can override that by supplying a parseable date
+    in the DATE environment variable.
+
+    If a weeklinks snip for the relevant GFR week does not exist,
+    it will exit with an error message.
+    DESC
+    task :publish do
+      app = Application.new
+
+      date = Date.parse(ENV['DATE']) rescue Date.today
+      week_number = weeks_since_incorporation(date).to_i
+      snip_name = "week-#{week_number}-links"
+      snip = app.soup[snip_name]
+      unless snip
+        abort "No weeklinks snip found for GFR week number #{week_number}"
+      end
+
+      snip.kind = 'blog'
+      snip.created_at = Time.now
+      snip.updated_at = Time.now
+      snip.save
+    end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -24,19 +24,21 @@ def weeks_since_incorporation(date)
   days_since_incorporation / 7.0
 end
 
-desc <<-DESC
-Displays the GFR week number from the date of incorporation.
+namespace :week do
+  desc <<-DESC
+  Displays the GFR week number from the date of incorporation.
 
-It defaults to today's date but you can override that by supplying
-a parseable date in the GFR_DATE environment variable.
+  It defaults to today's date but you can override that by supplying
+  a parseable date in the GFR_DATE environment variable.
 
-Example: `GFR_DATE=2014-03-24 rake display_gfr_week_number`
-=> Week beginning 24 Mar 2014 is week 271
-DESC
-task :display_gfr_week_number do
-  date = Date.parse(ENV['GFR_DATE']) rescue Date.today
-  week_number = weeks_since_incorporation(date).to_i
-  week_beginning = monday_beginning(date).strftime("%d %b %Y")
+  Example: `GFR_DATE=2014-03-24 rake week:number`
+  => Week beginning 24 Mar 2014 is week 271
+  DESC
+  task :number do
+    date = Date.parse(ENV['GFR_DATE']) rescue Date.today
+    week_number = weeks_since_incorporation(date).to_i
+    week_beginning = monday_beginning(date).strftime("%d %b %Y")
 
-  puts "Week beginning #{week_beginning} is week #{week_number}"
+    puts "Week beginning #{week_beginning} is week #{week_number}"
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -35,6 +35,8 @@ Example: `GFR_DATE=2014-03-24 rake display_gfr_week_number`
 DESC
 task :display_gfr_week_number do
   date = Date.parse(ENV['GFR_DATE']) rescue Date.today
+  week_number = weeks_since_incorporation(date).to_i
+  week_beginning = monday_beginning(date).strftime("%d %b %Y")
 
-  puts "Week beginning #{monday_beginning(date).strftime("%d %b %Y")} is week #{weeks_since_incorporation(date).to_i}"
+  puts "Week beginning #{week_beginning} is week #{week_number}"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -75,5 +75,32 @@ namespace :week do
       snip.content.gsub!(/Week NNN/, "Week #{week_number}")
       snip.save
     end
+
+    desc <<-DESC
+    Prepares the current weeknotes snip for publication.
+
+    By default it calculates the GFR week number based on today's
+    date, but you can override that by supplying a parseable date
+    in the DATE environment variable.
+
+    If a weeknotes snip for the relevant GFR week does not exist,
+    it will exit with an error message.
+    DESC
+    task :publish do
+      app = Application.new
+
+      date = Date.parse(ENV['DATE']) rescue Date.today
+      week_number = weeks_since_incorporation(date).to_i
+      snip_name = "week-#{week_number}"
+      snip = app.soup[snip_name]
+      unless snip
+        abort "No weeknotes snip found for GFR week number #{week_number}"
+      end
+
+      snip.kind = 'blog'
+      snip.created_at = Time.now
+      snip.updated_at = Time.now
+      snip.save
+    end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -29,13 +29,13 @@ namespace :week do
   Displays the GFR week number from the date of incorporation.
 
   It defaults to today's date but you can override that by supplying
-  a parseable date in the GFR_DATE environment variable.
+  a parseable date in the DATE environment variable.
 
-  Example: `GFR_DATE=2014-03-24 rake week:number`
+  Example: `DATE=2014-03-24 rake week:number`
   => Week beginning 24 Mar 2014 is week 271
   DESC
   task :number do
-    date = Date.parse(ENV['GFR_DATE']) rescue Date.today
+    date = Date.parse(ENV['DATE']) rescue Date.today
     week_number = weeks_since_incorporation(date).to_i
     week_beginning = monday_beginning(date).strftime("%d %b %Y")
 


### PR DESCRIPTION
This was basically a tactic to avoid writing the weeknotes, but maybe it's useful?

```
$ rake -T week
rake week:links:create   # Creates a new weeklinks snip for the current GFR week
rake week:links:publish  # Prepares the current weeklinks snip for publication
rake week:notes:create   # Creates a new weeknotes snip for the current GFR week
rake week:notes:publish  # Prepares the current weeknotes snip for publication
rake week:number         # Displays the GFR week number from the date of incorporation
```