### PR TITLE
Only display three significant projects on the home page

### DIFF
--- a/soups/projects.snip
+++ b/soups/projects.snip
@@ -1,0 +1,43 @@
+<h2>Projects</h2>
+
+<ol id="project-list">
+  <li>
+    {project smart-answers}
+  </li>
+  <li>
+    {project gfr-video}
+  </li>
+  <li>
+    {project credit-union}
+  </li>
+  <li>
+    {project makie}
+  </li>
+  <li>
+    {project futurelearn-video}
+  </li>
+  <li>
+    {project futurelearn}
+  </li>
+  <li>
+    {project harmonia}
+  </li>
+  <li>
+    {project government-single-domain}
+  </li>
+  <li>
+    {project voicenet}
+  </li>
+  <li>
+    {project hashblue}
+  </li>
+  <li>
+    {project mubi}
+  </li>
+  <li>
+    {project caffeine-monitor}
+  </li>
+  <li>
+    {project chromaroma}
+  </li>
+</ol>

--- a/soups/work.snip
+++ b/soups/work.snip
@@ -1,45 +1,18 @@
 <div id="work" class="section group">
-  <h2>Recent Work</h2>
+  <h2>Significant Projects</h2>
 
   <ol id="project-list">
     <li>
-      {project smart-answers}
-    </li>
-    <li>
-      {project gfr-video}
-    </li>
-    <li>
-      {project credit-union}
-    </li>
-    <li>
-      {project makie}
-    </li>
-    <li>
-      {project futurelearn-video}
-    </li>
-    <li>
       {project futurelearn}
-    </li>
-    <li>
-      {project harmonia}
     </li>
     <li>
       {project government-single-domain}
     </li>
     <li>
-      {project voicenet}
-    </li>
-    <li>
       {project hashblue}
     </li>
-    <li>
-      {project mubi}
-    </li>
-    <li>
-      {project caffeine-monitor}
-    </li>
-    <li>
-      {project chromaroma}
-    </li>
   </ol>
+  <p>
+    <a href="/projects">Fuller list of projects</a>
+  </p>
 </div>


### PR DESCRIPTION
Trello card: https://trello.com/c/vJA6vOFn

I've extracted all the projects into a separate page and link to it
from the bottom of the list on the home page.

Note that I've chosen to include the projects on the home page in
the separate list, because this made more sense to me i.e. the
separate page is intended to be a full list of projects.