### PR TITLE
Provide links back to S&T index page and other recent S&T event pages

### DIFF
--- a/lib/blog_renderer.rb
+++ b/lib/blog_renderer.rb
@@ -16,7 +16,7 @@ module Vanilla::Renderers
       author = @app.soup[@snip.author]
       author_name = author.name.split("-").map { |s| s.capitalize }.join(" ")
       author_image = author.image
-      template = @app.soup['blog-template']
+      template = @app.soup["#{@snip.kind}-template"]
       @app.render(template).gsub("ENTRY_CONTENT", entry_content).gsub("ENTRY_AUTHOR_IMAGE", author_image).gsub("ENTRY_AUTHOR", author_name).gsub("ENTRY_DATE", article_date(@snip.created_at))
     end
 

--- a/soups/layouts/show-and-tell-layout.snip
+++ b/soups/layouts/show-and-tell-layout.snip
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    {shared-html-head}
+    <title>
+      {page_title "Show and Tell event"} &mdash; Go Free Range.
+    </title>
+  </head>
+  <body class='blog'>
+    <div id='page'>
+      <div class='group' id='header'>
+        <ul class='nav group' id='blog_nav'>
+          <li id='link_home'>
+            <p>
+              Visit our
+              <a href='/'>company website</a>
+            </p>
+          </li>
+          <li id='link_rss'>
+            <p>
+              Grab the
+              <a href='http://feeds.gofreerange.com/GoFreeRangeBlog' title='RSS Feed from Feedburner'>RSS</a>
+              feed
+            </p>
+          </li>
+        </ul>
+        <h1 id='logo'>
+          <a href='/show-and-tell-events' title='Go to Show and Tell index'>Show and Tell index</a>
+        </h1>
+      </div>
+      <div class='group' id='content'>
+        {current_snip}
+      </div>
+    </div>
+    {javascripts}
+  </body>
+</html>

--- a/soups/show-and-tell/show-and-tell-10.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-10.snip.markdown
@@ -64,3 +64,4 @@ Until next time.
 :created_at: 2015-03-12 14:30:00 +00:00
 :updated_at: 2015-03-13 13:00:00 +00:00
 :page_title: Show and Tell 10
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-11.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-11.snip.markdown
@@ -63,3 +63,4 @@ Until next time.
 :created_at: 2015-04-16 13:00:00 +01:00
 :updated_at: 2015-04-17 13:00:00 +01:00
 :page_title: Show and Tell 11
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-12.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-12.snip.markdown
@@ -68,3 +68,4 @@ Until next time.
 :created_at: 2015-05-15 12:00:00 +01:00
 :updated_at: 2015-05-15 15:05:00 +01:00
 :page_title: Show and Tell 12
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-13.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-13.snip.markdown
@@ -72,3 +72,4 @@ Until next time.
 :created_at: 2015-06-26 15:20:00 +01:00
 :updated_at: 2015-06-26 17:20:00 +01:00
 :page_title: Show and Tell 13
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-14.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-14.snip.markdown
@@ -102,3 +102,4 @@ Until next time.
 :created_at: 2015-07-20 15:44:00 +01:00
 :updated_at: 2015-07-20 17:59:00 +01:00
 :page_title: Show and Tell 14
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-15.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-15.snip.markdown
@@ -87,3 +87,4 @@ Until next time.
 :created_at: 2015-08-14 11:10:00 +01:00
 :updated_at: 2015-08-14 11:10:00 +01:00
 :page_title: Show and Tell 15
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-16.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-16.snip.markdown
@@ -109,3 +109,4 @@ Thanks to everyone for coming. Hope to see you next time.
 :created_at: 2015-09-11 15:48:00 +01:00
 :updated_at: 2015-09-11 15:48:00 +01:00
 :page_title: Show and Tell 16
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-17.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-17.snip.markdown
@@ -85,3 +85,4 @@ Until next time,
 :created_at: 2015-10-16 15:25:00 +01:00
 :updated_at: 2015-10-16 15:25:00 +01:00
 :page_title: Show and Tell 17
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-18.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-18.snip.markdown
@@ -96,3 +96,4 @@ Until next time,
 :created_at: 2015-11-20 15:02:00 +01:00
 :updated_at: 2015-11-20 15:02:00 +01:00
 :page_title: Show and Tell 18
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-19.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-19.snip.markdown
@@ -84,3 +84,4 @@ I talked a little bit about [Google Maps Timeline][google-maps-timeline] (previo
 :created_at: 2016-01-25 13:30:00 +13:00
 :updated_at: 2016-01-25 13:30:00 +13:00
 :page_title: Show and Tell 19
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-20.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-20.snip.markdown
@@ -81,3 +81,4 @@ Until next time,
 :created_at: 2016-07-29 17:09:00 +01:00
 :updated_at: 2016-07-29 17:09:00 +01:00
 :page_title: Show and Tell 20
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-21.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-21.snip.markdown
@@ -90,3 +90,4 @@ Until next time,
 :created_at: 2016-08-05 16:18:00 +01:00
 :updated_at: 2016-08-05 16:18:00 +01:00
 :page_title: Show and Tell 21
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-22.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-22.snip.markdown
@@ -40,3 +40,4 @@ Until next time,
 :created_at: 2016-08-15 12:09:00 +01:00
 :updated_at: 2016-08-16 13:36:00 +01:00
 :page_title: Show and Tell 22
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-23.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-23.snip.markdown
@@ -71,3 +71,4 @@ Please [get in touch][contact] if you're interested in joining us for the next S
 :created_at: 2016-08-26 11:08:00 +01:00
 :updated_at: 2016-08-26 11:08:00 +01:00
 :page_title: Show and Tell 23
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-24.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-24.snip.markdown
@@ -137,3 +137,4 @@ I think it's great that Rob's tweaking the courses to try to give students a mor
 :created_at: 2016-09-22 11:12:00 +01:00
 :updated_at: 2016-09-22 11:12:00 +01:00
 :page_title: Show and Tell 24
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-25.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-25.snip.markdown
@@ -133,3 +133,4 @@ I can imagine adding the Brewfile to my dotfiles repo and potentially switching 
 :created_at: 2016-10-14 17:20:00 +01:00
 :updated_at: 2016-10-14 17:20:00 +01:00
 :page_title: Show and Tell 25
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-26.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-26.snip.markdown
@@ -123,3 +123,4 @@ James showed us how he's been
 :author: chris-roos
 :page_title: Show and Tell 26
 :extension: markdown
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-27.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-27.snip.markdown
@@ -18,3 +18,4 @@ Show and Tell 27
 :author: chris-roos
 :page_title: Show and Tell 27
 :extension: markdown
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-4.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-4.snip.markdown
@@ -49,3 +49,4 @@ If this sounds like the sort of thing you're interested in, then please do [get 
 :created_at: 2014-08-07 17:00:00 +01:00
 :updated_at: 2014-08-07 17:00:00 +01:00
 :page_title: Show and Tell 4
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-5.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-5.snip.markdown
@@ -64,3 +64,4 @@ Although not technically part of the Show and Tell, [Murray][] was keen to show 
 :created_at: 2014-09-15 17:30:00 +01:00
 :updated_at: 2014-09-15 17:30:00 +01:00
 :page_title: Show and Tell 5
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-6.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-6.snip.markdown
@@ -62,3 +62,4 @@ Anyway, that's all for this month!
 :created_at: 2014-10-13 16:57:00 +01:00
 :updated_at: 2014-10-13 16:57:00 +01:00
 :page_title: Show and Tell 6
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-7.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-7.snip.markdown
@@ -50,3 +50,4 @@ The meeting then reconvened in the pub, but I had to slip away. So that's all I 
 :created_at: 2014-11-17 14:28:00 +01:00
 :updated_at: 2014-11-17 14:28:00 +01:00
 :page_title: Show and Tell 7
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-8.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-8.snip.markdown
@@ -69,3 +69,4 @@ Anyway, that's your lot for this month. Our [Show & Tell event][] is taking a br
 :created_at: 2014-12-12 11:53:00 +01:00
 :updated_at: 2014-12-17 16:44:00 +01:00
 :page_title: Show and Tell 8
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-9.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-9.snip.markdown
@@ -71,3 +71,4 @@ I really enjoyed the evening and I'm glad we decided to keep it up despite not h
 :created_at: 2015-02-16 14:30:00 +01:00
 :updated_at: 2015-02-16 17:45:00 +01:00
 :page_title: Show and Tell 9
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-nn.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-nn.snip.markdown
@@ -12,3 +12,4 @@ Show and Tell NN
 :created_at: 2016-10-14 17:20:00 +01:00
 :updated_at: 2016-10-14 17:20:00 +01:00
 :page_title: Show and Tell NN
+:layout: show-and-tell-layout

--- a/soups/show-and-tell/show-and-tell-template.snip.haml
+++ b/soups/show-and-tell/show-and-tell-template.snip.haml
@@ -1,0 +1,22 @@
+.blog_entry.group
+  %p.article_date
+    ENTRY_DATE
+
+  .author
+    %img{:src => "ENTRY_AUTHOR_IMAGE", :alt => "ENTRY_AUTHOR"}
+    %span
+      by ENTRY_AUTHOR
+
+  .content
+    ENTRY_CONTENT
+
+  #comments.comments
+    - if ENV['RACK_ENV'] == 'production'
+      {disqus-commenting}
+    - else
+      Disqus commenting is only enabled in production.
+
+#article_links
+  %h3 Recent
+  %ul#recent_articles
+    {list-of kind:show-and-tell, limit:5}


### PR DESCRIPTION
Trello card: https://trello.com/c/IlpqXRkl

These commits introduce rather more duplication that I would like, but I couldn't see a better way of doing things.