### PR TITLE
Fix responsiveness for images in blog posts

### DIFF
--- a/app/assets/stylesheets/screen.scss.erb
+++ b/app/assets/stylesheets/screen.scss.erb
@@ -435,6 +435,10 @@ body.blog, body.wiki {
 
         .content {
           padding-top: 0.7em;
+
+          img {
+            max-width: 100%;
+          }
         }
 
         .author {


### PR DESCRIPTION
Previously on narrow devices the text would not reduce in width in line with the text. By limiting the width of images to the width of the content container, the width of both text and images remains in line with each other.

I've tried to demonstrate the effect of this change in the screenshots below. Note that it also reduces the width of the images on a desktop width browser to the width of the text content, but I think this also looks better.

I think there's a separate argument to be had that the content width should be wider, but I think we can deal with that separately.

## Mobile width

### Before

<img width="284" alt="mobile-before" src="https://user-images.githubusercontent.com/3169/31969280-f7c94c26-b90b-11e7-95d4-c3c3661bf2c9.png">

### After

<img width="281" alt="mobile-after" src="https://user-images.githubusercontent.com/3169/31969292-057b6fe8-b90c-11e7-8495-9fa0a6c239e9.png">

## Desktop width

### Before

<img width="1077" alt="desktop-before" src="https://user-images.githubusercontent.com/3169/31969302-0db318a0-b90c-11e7-80b5-a8bfb33c8daf.png">

### After

<img width="1076" alt="desktop-after" src="https://user-images.githubusercontent.com/3169/31969310-148fcbbe-b90c-11e7-9199-688db209d70f.png">

@chrislo, @chrisroos: What do you think?