### PR TITLE
Add Slackin widget to S&T related pages

### DIFF
--- a/app/assets/stylesheets/screen.scss.erb
+++ b/app/assets/stylesheets/screen.scss.erb
@@ -731,7 +731,7 @@ body.blog, body.wiki {
         #article_links {
           margin-top: 0.5em;
           width: 19.5%;
-          padding: 2em 2.5em 0 2.5em;
+          padding: 2em 2.5em 2em 2.5em;
           background: #fff;
           border: 1px solid #dcdcdc;
           float: left;

--- a/app/views/layouts/show-and-tell.html.erb
+++ b/app/views/layouts/show-and-tell.html.erb
@@ -46,6 +46,7 @@
                 <%= content_tag(:li, link_to(snip.page_title, url_to(snip.name)), value: index) %>
               <% end %>
             </ol>
+            <%= render partial: 'shared/slackin' %>
           </div>
         </div>
       </div>

--- a/app/views/shared/_slackin.html
+++ b/app/views/shared/_slackin.html
@@ -1,0 +1,1 @@
+<script async defer src="https://gfr-show-and-tell-slack.herokuapp.com/slackin.js?"></script>

--- a/soups/show-and-tell-events.snip.markdown
+++ b/soups/show-and-tell-events.snip.markdown
@@ -26,7 +26,7 @@ If you have any questions, please [get in touch][email-address].
   **Note 2.**
   Subscribing to the Google Group will automatically invite you to a recurring calendar event for the Show & Tell.
 
-* [Slack channel][]
+* [Slack channel][] <%= render partial: 'shared/slackin' %>
 * [Events on Attending][]
 * [Event series on Lanyrd (deprecated)][lanyrd-event-series]
 


### PR DESCRIPTION
* Added widget to index page in Communication section
* Added widget to sidebar on individual S&T event pages

This allows people to signup to the Slack channel directly from our website.