### PR TITLE
Add a first stab at content for 2018 internal/client projects

### DIFF
--- a/soups/projects.snip.html
+++ b/soups/projects.snip.html
@@ -1,6 +1,15 @@
 <h2>Projects</h2>
 
 <ol id="project-list">
+  <li id="mission-patch">
+    <%= project 'mission-patch' %>
+  </li>
+  <li id="crown-marketplace">
+    <%= project 'crown-marketplace' %>
+  </li>
+  <li id="trainline">
+    <%= project 'trainline' %>
+  </li>
   <li id="bbc-voice">
     <%= project 'bbc-voice' %>
   </li>

--- a/soups/projects/crown-marketplace.snip.markdown
+++ b/soups/projects/crown-marketplace.snip.markdown
@@ -1,0 +1,7 @@
+We worked with the [Crown Commerical Service](https://www.crowncommercial.gov.uk) (via [dxw digital](https://www.dxw.com/)) to prototype and build a digital service for public sector organisations to buy value-for-money goods and services in an efficient way. The project focussed on [a service for schools to find supply teachers and agency workers](https://marketplace.service.crowncommercial.gov.uk/supply-teachers) which was developed in collaboration with [DfE](https://www.gov.uk/government/organisations/department-for-education) and launched in January 2019.
+
+:display_name: Crown Marketplace for the Crown Commercial Service
+:url: https://www.crowncommercial.gov.uk
+
+:created_at: 2019-02-10 11:55:00 +0100
+:updated_at: 2019-02-10 11:55:00 +0100

--- a/soups/projects/mission-patch.snip.markdown
+++ b/soups/projects/mission-patch.snip.markdown
@@ -1,0 +1,7 @@
+We built [mission-patch.com](https://mission-patch.com) to help product people celebrate success with a set of mission patch laptop stickers for their team. This makes it easy to create beautiful distinctive custom stickers and you can either download print-ready artwork or have us print them for you.
+
+:display_name: Mission Patch
+:url: https://mission-patch.com
+
+:created_at: 2019-02-10 12:19:00 +0100
+:updated_at: 2019-02-10 12:19:00 +0100

--- a/soups/projects/trainline.snip.markdown
+++ b/soups/projects/trainline.snip.markdown
@@ -1,0 +1,7 @@
+We worked with the [Trainline](https://www.thetrainline.com/) to improve their generic access layer for European ticket-booking providers and helped add some new providers.
+
+:display_name: Trainline
+:url: https://www.thetrainline.com/
+
+:created_at: 2019-02-10 12:04:00 +0100
+:updated_at: 2019-02-10 12:04:00 +0100


### PR DESCRIPTION
Please feel free to suggest changes or additions to this content, particularly if I've misrepresented something or said something commercially sensitive.

These will appear on [the projects page][1] which is linked to as "Fuller list of projects" under the ["Significant projects" section][2] on the home page.

We might want to consider updating the this "Significant projects" section to include one or two of our more recent projects.

[1]: https://gofreerange.com/projects
[2]: https://gofreerange.com/#work