### PR TITLE
Replace Slackin widget with link to new Show & Tell Slack invitation page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'capybara'
   gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'timecop'

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
     airbrake (5.8.1)
       airbrake-ruby (~> 1.8)
     airbrake-ruby (1.8.0)
@@ -62,6 +64,14 @@ GEM
     bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
+    capybara (3.13.2)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.2)
+      xpath (~> 3.2)
     concurrent-ruby (1.1.4)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -101,6 +111,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
     rack-test (1.1.0)
@@ -137,6 +148,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    regexp_parser (1.3.0)
     rspec-core (3.6.0)
       rspec-support (~> 3.6.0)
     rspec-expectations (3.6.0)
@@ -185,6 +197,8 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -193,6 +207,7 @@ DEPENDENCIES
   airbrake (~> 5)
   aws-sdk-s3
   bootsnap (>= 1.1.0)
+  capybara
   dotenv-rails
   kramdown
   listen (>= 3.0.5, < 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.2)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -195,6 +199,7 @@ DEPENDENCIES
   mini_racer
   puma (~> 3.11)
   rails (~> 5.2.2)
+  rails-controller-testing
   rspec-rails
   sass-rails
   soup

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ So that exceptions are reported to our Errbit app. You may need to create a new 
     $ rails secret | pbcopy
     $ heroku config:set SECRET_KEY_BASE=`pbpaste`
 
+### Configure Slack API key for Show & Tell
+
+    $ heroku config:set SLACK_API_TOKEN=<value-obtained-from-slack>
+
 ## Writing a snip
 
 A snip is just a text file within the "soup", like "here-is-my-stuff.snip". You can write whatever you like in the file, and it will be rendered as is when you visit http://yoursite/here-is-my-stuff.

--- a/app/assets/stylesheets/screen.scss.erb
+++ b/app/assets/stylesheets/screen.scss.erb
@@ -424,6 +424,28 @@ body.blog, body.wiki {
     #content {
       padding: 1.4em 2.5em 0 2.5em;
 
+      #show-and-tell-slack-channel {
+        float: left;
+
+        .flash-notice {
+          color: #155724;
+          background-color: #d4edda;
+          border-color: #c3e6cb;
+          margin: 0.7rem;
+          padding: 0.3rem;
+          border: 1px solid;
+        }
+
+        .flash-alert {
+          color: #721c24;
+          background-color: #f8d7da;
+          border-color: #f5c6cb;
+          margin: 0.7rem;
+          padding: 0.3rem;
+          border: 1px solid;
+        }
+      }
+
       .blog_entry {
 
         p.article_date {

--- a/app/controllers/slack/invitations_controller.rb
+++ b/app/controllers/slack/invitations_controller.rb
@@ -1,0 +1,52 @@
+module Slack
+  class InvitationsController < ApplicationController
+    layout 'wiki'
+
+    SLACK_SUBDOMAIN = 'gfr-show-and-tell'.freeze
+    SLACK_ENDPOINT = URI("https://#{SLACK_SUBDOMAIN}.slack.com/api/users.admin.invite").freeze
+
+    def new
+      @invitation = Invitation.new
+      @page_title = 'Show & Tell Slack Channel'
+    end
+
+    def create
+      @invitation = Invitation.new(params.permit(:email))
+
+      unless @invitation.valid?
+        error_message = @invitation.errors.full_messages.to_sentence
+        flash.now[:alert] = "Validation error: #{error_message}"
+        render :new
+        return
+      end
+
+      response = Net::HTTP.post_form(SLACK_ENDPOINT, {
+        email: @invitation.email,
+        channels: SLACK_SUBDOMAIN,
+        set_active: true,
+        _attempts: 1,
+        token: ENV['SLACK_API_TOKEN']
+      })
+
+      unless response.code == '200'
+        error_message = "Slack API error: #{response.code} #{response.message}"
+        notify_airbrake(error_message)
+        flash.now[:alert] = error_message
+        render :new
+        return
+      end
+
+      json = JSON.parse(response.body)
+      unless json['ok']
+        error_message = "Slack API error: #{json['error']}"
+        notify_airbrake(error_message)
+        flash.now[:alert] = error_message
+        render :new
+        return
+      end
+
+      notice = 'Invitation sent!'
+      redirect_to new_slack_invitation_path, flash: { notice: notice }
+    end
+  end
+end

--- a/app/models/slack/invitation.rb
+++ b/app/models/slack/invitation.rb
@@ -1,0 +1,10 @@
+module Slack
+  class Invitation
+    include ActiveModel::Model
+    attr_accessor :email
+
+    validates :email,
+      presence: true,
+      format: { with: URI::MailTo::EMAIL_REGEXP, allow_blank: true }
+  end
+end

--- a/app/views/layouts/show-and-tell.html.erb
+++ b/app/views/layouts/show-and-tell.html.erb
@@ -46,7 +46,6 @@
                 <%= content_tag(:li, link_to_snip(snip), value: index) %>
               <% end %>
             </ol>
-            <%= render partial: 'shared/slackin' %>
           </div>
         </div>
       </div>

--- a/app/views/layouts/wiki.html.erb
+++ b/app/views/layouts/wiki.html.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render partial: 'shared/head' %>
     <title>
-      <%= @snip.page_title || 'Wiki' %> &mdash; Go Free Range.
+      <%= (@snip && @snip.page_title) || content_for(:page_title) || 'Wiki' %> &mdash; Go Free Range.
     </title>
   </head>
   <body class="wiki">

--- a/app/views/shared/_slackin.html
+++ b/app/views/shared/_slackin.html
@@ -1,1 +1,0 @@
-<script async defer src="//gfr-show-and-tell-slack.herokuapp.com/slackin.js?"></script>

--- a/app/views/slack/invitations/new.html.erb
+++ b/app/views/slack/invitations/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>
+  Show & Tell Slack Channel
+<% end %>
+
+<div id="show-and-tell-slack-channel" class="section group">
+  <h2>Show & Tell Slack Channel</h2>
+
+  <% if flash[:alert].present? %>
+    <p class="flash-alert"><%= flash[:alert] %></p>
+  <% end %>
+  <% if flash[:notice].present? %>
+    <p class="flash-notice"><%= flash[:notice] %></p>
+  <% end %>
+
+  <ul>
+    <li><%= link_to 'Sign In', 'https://gfr-show-and-tell.slack.com/' %></li>
+    <li>
+      <%= form_tag slack_invitations_path, id: 'slack-invitation' do %>
+        <%= email_field_tag 'email', '', placeholder: 'Email address' %>
+        <%= submit_tag 'Request Invitation' %>
+      <% end %>
+    </li>
+  </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,10 @@ Rails.application.routes.draw do
     resources :assets, only: %(show)
   end
 
+  namespace :slack do
+    resources :invitations, only: %i(new create)
+  end
+
   get '/hello-printer', to: redirect('https://exciting.io/2012/04/12/hello-printer')
   get '/printer-questions', to: redirect('https://exciting.io/2012/05/01/printer-questions')
   get '/printer-kit', to: redirect('https://exciting.io/printer')

--- a/soups/show-and-tell-events.snip.markdown
+++ b/soups/show-and-tell-events.snip.markdown
@@ -24,7 +24,8 @@ If you have any questions, please [get in touch][email-address].
   **Note 2.**
   Subscribing to the Google Group will automatically invite you to a recurring calendar event for the Show & Tell.
 
-* [Slack channel][] <%= render partial: 'shared/slackin' %>
+* [Slack channel][]
+* <%= link_to 'Request an invitation to the Slack channel', new_slack_invitation_path %>
 * [Events on Upcoming][upcoming-event-series]
 * [Events on Attending (deprecated)][attending-event-series]
 * [Event series on Lanyrd (deprecated)][lanyrd-event-series]

--- a/spec/controllers/slack/invitations_controller.rb
+++ b/spec/controllers/slack/invitations_controller.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+describe Slack::InvitationsController do
+  describe 'GET #new' do
+    it 'assigns invitation' do
+      get :new
+      expect(assigns(:invitation)).to be_instance_of(Slack::Invitation)
+    end
+  end
+
+  describe 'POST #create' do
+    let(:slack_subdomain) { Slack::InvitationsController::SLACK_SUBDOMAIN }
+    let(:slack_endpoint) { Slack::InvitationsController::SLACK_ENDPOINT }
+
+    let(:email) { 'joe@example.com' }
+    let(:params) { { email: email } }
+
+    let(:code) { '200' }
+    let(:message) { nil }
+
+    let(:ok) { true }
+    let(:error) { nil }
+    let(:body) { { ok: ok, error: error }.to_json }
+
+    let(:slack_response) do
+      instance_double('Net::HTTPOK', code: code, message: message, body: body)
+    end
+
+    let(:slack_api_token) { 'slack-api-token' }
+
+    before do
+      allow(Net::HTTP).to receive(:post_form).and_return(slack_response)
+      ENV['SLACK_API_TOKEN'] = slack_api_token
+    end
+
+    it 'posts form to Slack endpoint to send invitation' do
+      post :create, params: params
+      expect(Net::HTTP).to have_received(:post_form)
+        .with(slack_endpoint, anything)
+    end
+
+    it 'posts form data to send invitation' do
+      post :create, params: params
+      expect(Net::HTTP).to have_received(:post_form)
+        .with(anything, include(
+          email: email,
+          channels: slack_subdomain,
+          set_active: true,
+          _attempts: 1,
+          token: slack_api_token
+        ))
+    end
+
+    it 'redirects to new action' do
+      post :create, params: params
+      expect(response).to redirect_to(new_slack_invitation_path)
+    end
+
+    it 'sets flash notice' do
+      post :create, params: params
+      expect(flash[:notice]).to eq('Invitation sent!')
+    end
+
+    context 'when email is invalid' do
+      let(:email) { '' }
+      let(:error_message) { "Validation error: Email can't be blank" }
+
+      it 'renders new template' do
+        post :create, params: params
+        expect(response).to render_template(:new)
+      end
+
+      it 'sets flash alert to error message' do
+        post :create, params: params
+        expect(flash.now[:alert]).to eq(error_message)
+      end
+    end
+
+    context 'when response code is not 200 OK' do
+      let(:code) { '500' }
+      let(:message) { 'Internal server error' }
+      let(:error_message) { 'Slack API error: 500 Internal server error' }
+
+      it 'renders new template' do
+        post :create, params: params
+        expect(response).to render_template(:new)
+      end
+
+      it 'sets flash alert to error message' do
+        post :create, params: params
+        expect(flash.now[:alert]).to eq(error_message)
+      end
+
+      it 'reports error to airbrake' do
+        expect(controller).to receive(:notify_airbrake).with(error_message)
+        post :create, params: params
+      end
+    end
+
+    context 'when ok is not true' do
+      let(:ok) { false }
+      let(:error) { 'already_invited' }
+      let(:error_message) { 'Slack API error: already_invited' }
+
+      it 'renders new template' do
+        post :create, params: params
+        expect(response).to render_template(:new)
+      end
+
+      it 'sets flash alert to error message' do
+        post :create, params: params
+        expect(flash.now[:alert]).to eq(error_message)
+      end
+
+      it 'reports error to airbrake' do
+        expect(controller).to receive(:notify_airbrake).with(error_message)
+        post :create, params: params
+      end
+    end
+  end
+end

--- a/spec/models/slack/invitation_spec.rb
+++ b/spec/models/slack/invitation_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe Slack::Invitation do
+  subject(:invitation) { Slack::Invitation.new(email: email) }
+
+  describe 'validation' do
+    context 'when email is valid' do
+      let(:email) { 'joe@example.com' }
+
+      it 'is valid' do
+        expect(invitation).to be_valid
+      end
+    end
+
+    context 'when email is blank' do
+      let(:email) { '' }
+
+      it 'is not valid' do
+        expect(invitation).not_to be_valid
+      end
+
+      it 'has presence error on email' do
+        invitation.valid?
+        expect(invitation.errors[:email]).to include("can't be blank")
+      end
+
+      it 'does not have format error on email' do
+        invitation.valid?
+        expect(invitation.errors[:email]).not_to include('is invalid')
+      end
+    end
+
+    context 'when email is invalid' do
+      let(:email) { 'invalid-email' }
+
+      it 'is not valid' do
+        expect(invitation).not_to be_valid
+      end
+
+      it 'does not have presence error on email' do
+        invitation.valid?
+        expect(invitation.errors[:email]).not_to include("can't be blank")
+      end
+
+      it 'has format error on email' do
+        invitation.valid?
+        expect(invitation.errors[:email]).to include('is invalid')
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,3 +43,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+require 'capybara/rspec'

--- a/spec/views/slack/invitations/new.html.erb_spec.rb
+++ b/spec/views/slack/invitations/new.html.erb_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe 'slack/invitations/new.html.erb' do
+  context 'when flash alert is present' do
+    before do
+      flash[:alert] = 'Alert!'
+    end
+
+    it 'renders alert text' do
+      render
+      expect(rendered).to have_css('.flash-alert', text: 'Alert!')
+    end
+  end
+
+  context 'when flash alert is not present' do
+    it 'renders alert text' do
+      render
+      expect(rendered).not_to have_css('.flash-alert')
+    end
+  end
+
+  context 'when flash notice is present' do
+    before do
+      flash[:notice] = 'Notice!'
+    end
+
+    it 'renders notice text' do
+      render
+      expect(rendered).to have_css('.flash-notice', text: 'Notice!')
+    end
+  end
+
+  context 'when flash notice is not present' do
+    it 'renders notice text' do
+      render
+      expect(rendered).not_to have_css('.flash-notice')
+    end
+  end
+
+  it 'renders sign-in link for Slack channel' do
+    render
+    expect(rendered).to have_link('Sign In', href: 'https://gfr-show-and-tell.slack.com/')
+  end
+
+  it 'renders form with action to create invitation' do
+    render
+    expect(rendered).to have_css(%{form[action="#{slack_invitations_path}"]})
+  end
+
+  it 'renders form with email address field' do
+    render
+    expect(rendered).to have_css('form input[type="email"][name="email"]')
+  end
+
+  it 'renders form with submit button' do
+    render
+    expect(rendered).to have_css('form input[type="submit"][value="Request Invitation"]')
+  end
+end


### PR DESCRIPTION
[Slackin](https://github.com/rauchg/slackin) doesn't appear to be very actively maintained and it's not obvious that we're getting enough value for it to merit the cost of a separate Heroku app and all the time spent maintaining it.

This PR adds a new page where you can request an invitation to the Show & Tell Slack team which is the main thing that Slackin gave us.

Ideally I think this could be implemented as a servless app, but given that we already have the Twilio functionality in this app, I don't think this is really making things worse and it should mean we can decommission our instance of Slackin from Heroku.

I've preemptively added the `SLACK_API_TOKEN` env var to the Heroku app for this repo to make sure I don't forget to do it if/when we merge this PR.

What do people think?