### PR TITLE
Fix the heading number for the next show and tell

### DIFF
--- a/soups/show-and-tell/show-and-tell-54.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-54.snip.markdown
@@ -65,7 +65,7 @@ There seems to be a bit of buzz about [Platform Coops][platform-coop] at the mom
 [upcoming]: https://upcoming.org/
 
 
-## Show & Tell 48
+## Show & Tell 55
 
 We'll host our next Show & Tell on 15th May. [Email us][email-us] if you'd like to be added to the mailing list so that you're notified of [upcoming events][show-and-tell-events].
 


### PR DESCRIPTION
I wrote a quick thing to do a more exhaustive check:

```ruby
# If a show and tell writeup references the next meeting, check
# that its number is one greater than the number in the filename.

Dir.glob("soups/show-and-tell/*").each do |path|
  File.readlines(path).each do |line|
    next unless line.start_with?("#")
    next unless line.downcase.include?("show")
    next unless line.downcase.include?("tell")
    next unless line.match(/\d+/)

    expected = Integer(path[/\d+/]) + 1
    actual = Integer(line[/\d+/])

    unless expected == actual
      puts "#{path} might have the wrong heading #{line}"
    end
  end
end
```

It detects one other discrepancy in `show-and-tell-50` but that intentionally references `54` because it was written up several meetings later.

**TL;DR** everything looks good. 👍 