### PR TITLE
Explicitly enable ERB in snips

### DIFF
--- a/lib/snip_renderer.rb
+++ b/lib/snip_renderer.rb
@@ -1,11 +1,18 @@
 class SnipRenderer
   def render(snip, context)
-    content = ERB.new(snip.content).result(context)
-    case snip.extension
-    when 'markdown'
-      Kramdown::Document.new(content, input: 'GFM', syntax_highlighter: 'rouge').to_html
-    else
-      content
+    formats = []
+    formats << 'erb' if snip.erb
+    formats << 'markdown' if snip.extension == 'markdown'
+
+    formats.inject(snip.content) do |content, format|
+      case format
+      when 'erb'
+        ERB.new(content).result(context)
+      when 'markdown'
+        Kramdown::Document.new(content, input: 'GFM', syntax_highlighter: 'rouge').to_html
+      else
+        content
+      end
     end
   end
 end

--- a/soups/alumni.snip.html
+++ b/soups/alumni.snip.html
@@ -29,3 +29,4 @@
 :created_at: 2013-11-16 13:35:09 +0000
 :created_sha: baea334ca9d066e54b2808daef4cdac46f87f0e3
 :updated_at: 2017-08-19 10:50:48 +0100
+:erb: true

--- a/soups/blog.snip.markdown
+++ b/soups/blog.snip.markdown
@@ -13,3 +13,4 @@
 :created_sha: e3ec4ca2d47461b081d382aeee899e0622341696
 :updated_at: 2017-08-19 10:50:48 +0100
 :page_title: Assorted Essays
+:erb: true

--- a/soups/blog/automatic-backup-of-trello-boards-to-s3-using-aws-cdk.snip.markdown
+++ b/soups/blog/automatic-backup-of-trello-boards-to-s3-using-aws-cdk.snip.markdown
@@ -39,3 +39,4 @@ _This article was <a rel="canonical" href="https://jamesmead.org/blog/2020-03-30
 :updated_at: 2020-03-30 16:40:00 +00:00
 :page_title: Automatic backup of Trello boards to S3 using the AWS CDK
 :canonical_url: https://jamesmead.org/blog/2020-03-30-automatic-backup-of-trello-boards-to-s3-using-aws-cdk
+:erb: true

--- a/soups/blog/avoid-vat-issues-with-free-agent-sanity-check.snip.markdown
+++ b/soups/blog/avoid-vat-issues-with-free-agent-sanity-check.snip.markdown
@@ -76,3 +76,4 @@ At the moment, the *FreeAgent Sanity Check* is fairly customised to our company 
 :created_at: 2013-01-28 12:24:00 +01:00
 :updated_at: 2013-01-28 12:24:00 +01:00
 :page_title: Avoiding VAT issues with FreeAgent Sanity Check
+:erb: true

--- a/soups/blog/building-a-git-repository-of-ruby-method-definitions.snip.markdown
+++ b/soups/blog/building-a-git-repository-of-ruby-method-definitions.snip.markdown
@@ -38,3 +38,4 @@ Anyway, hopefully that's some food for thought. I'd love to hear what you think.
 :created_at: 2014-03-16 00:45:00 +00:00
 :updated_at: 2014-03-16 00:45:00 +00:00
 :page_title: Building a Git repository of Ruby method definitions
+:erb: true

--- a/soups/blog/extreme-startup-game.snip.markdown
+++ b/soups/blog/extreme-startup-game.snip.markdown
@@ -74,3 +74,4 @@ If you get the chance to have [Rob](http://chatley.com) run the Extreme Startup 
 :created_at: 2013-07-31 18:00:00 +06:00
 :updated_at: 2013-07-31 18:00:00 +06:00
 :page_title: Extreme Startup Game
+:erb: true

--- a/soups/blog/inside-government.snip.markdown
+++ b/soups/blog/inside-government.snip.markdown
@@ -66,3 +66,4 @@ There's a lot more work to do, but we're confident that [GDS][gds] will [listen 
 :created_at: 2012-02-29 12:45:00 +01:00
 :updated_at: 2012-02-29 12:45:00 +01:00
 :page_title: Inside Government
+:erb: true

--- a/soups/blog/linda-reads-your-numbers.snip.markdown
+++ b/soups/blog/linda-reads-your-numbers.snip.markdown
@@ -38,3 +38,4 @@ Go forth and [set up your contacts][linda] so that you too can get Linda to read
 :created_at: 2011-04-12 17:10:00 +01:00
 :updated_at: 2011-05-03 18:21:54 +01:00
 :page_title: Linda reads your numbers
+:erb: true

--- a/soups/blog/office-furniture-clearance.snip.markdown
+++ b/soups/blog/office-furniture-clearance.snip.markdown
@@ -59,3 +59,4 @@ We've had a bit of a sort-out in our office and we've identified some furniture 
 :created_at: 2014-07-16 12:30:00 +01:00
 :updated_at: 2014-07-16 12:30:00 +01:00
 :page_title: Office Furniture Clearance
+:erb: true

--- a/soups/blog/replacing-account-numbers-with-friendly-names-in-hsbc-uks-business-banking-site.snip.markdown
+++ b/soups/blog/replacing-account-numbers-with-friendly-names-in-hsbc-uks-business-banking-site.snip.markdown
@@ -37,3 +37,4 @@ This is very much a toy project but I can already see some things that we could 
 :created_at: 2014-02-07 13:25:00 +00:00
 :updated_at: 2014-02-07 13:25:00 +00:00
 :page_title: Replacing account numbers with friendly names in HSBC UK's business banking site
+:erb: true

--- a/soups/blog/say-hello-to-timmy-printface.snip.markdown
+++ b/soups/blog/say-hello-to-timmy-printface.snip.markdown
@@ -122,3 +122,4 @@ Incidentally, she collaborated with [Roo][] on the [Shift Run Stop](http://www.s
 :created_at: 2011-04-08 13:55:00 +01:00
 :updated_at: 2011-04-08 13:55:00 +01:00
 :page_title: Hello, Timmy
+:erb: true

--- a/soups/blog/serving-our-website-securely.snip.markdown
+++ b/soups/blog/serving-our-website-securely.snip.markdown
@@ -50,3 +50,4 @@ I hope that was useful!
 :created_at: 2018-08-31 17:08:00 +00:00
 :updated_at: 2018-08-31 17:08:00 +00:00
 :page_title: Serving our website securely
+:erb: true

--- a/soups/blog/what-have-we-been-doing.markdown
+++ b/soups/blog/what-have-we-been-doing.markdown
@@ -58,3 +58,4 @@ We also made some changes to the tech stack. We decided to move the backend proc
 :created_at: 2024-08-06 11:20:00 +00:00
 :updated_at: 2024-08-06 11:20:00 +00:00
 :page_title: What have we been doing recently?
+:erb: true

--- a/soups/blog/working-remotely.snip.markdown
+++ b/soups/blog/working-remotely.snip.markdown
@@ -127,3 +127,4 @@ Adieu, blogfolk!
 :created_at: 2012-01-25 00:05:00 +00:00
 :updated_at: 2012-01-25 00:05:00 +00:00
 :page_title: Working Remotely
+:erb: true

--- a/soups/company-info.snip.html
+++ b/soups/company-info.snip.html
@@ -3,3 +3,4 @@
 :created_at: 2011-03-29 12:29:25 +0100
 :created_sha: 14aa257ecef95d2afcd12af01765a7651b9d35f4
 :updated_at: 2017-08-19 10:50:48 +0100
+:erb: true

--- a/soups/contact.snip.markdown
+++ b/soups/contact.snip.markdown
@@ -14,3 +14,4 @@
 :created_at: 2017-07-23 17:41:29 +0100
 :created_sha: 898e1d7abebec46315789e45ef1abdff18303ccc
 :updated_at: 2019-04-30 17:25:00 +0100
+:erb: true

--- a/soups/data.snip.markdown
+++ b/soups/data.snip.markdown
@@ -36,3 +36,4 @@ We ran an [R](https://en.wikipedia.org/wiki/R_(programming_language)) training c
 
 :created_at: 2021-04-28 13:00:00 +0100
 :updated_at: 2021-04-28 13:00:00 +0100
+:erb: true

--- a/soups/gfr-video-about.snip.markdown
+++ b/soups/gfr-video-about.snip.markdown
@@ -36,3 +36,4 @@ This page contains the content from the now archived "about" page for [the servi
 :created_at: 2022-05-25 12:39:00 +0100
 :updated_at: 2022-05-25 12:39:00 +0100
 :page_title: GFR Video - About
+:erb: true

--- a/soups/people.snip.markdown
+++ b/soups/people.snip.markdown
@@ -23,3 +23,4 @@ Founded in 2009 on the basis of mutual respect for each others’ work and chara
 :created_at: 2010-07-21 13:12:26 +0100
 :created_sha: 3d10ae1f1a58883519a8bd92a44eb7f454a12ad5
 :updated_at: 2017-08-19 10:50:48 +0100
+:erb: true

--- a/soups/projects.snip.html
+++ b/soups/projects.snip.html
@@ -78,3 +78,4 @@
 :created_at: 2016-11-03 17:29:35 +0000
 :created_sha: 8aeea2f014edc7061eb9acbede1e9aab79c023f1
 :updated_at: 2017-08-19 10:50:48 +0100
+:erb: true

--- a/soups/projects/codeclubworld.snip.markdown
+++ b/soups/projects/codeclubworld.snip.markdown
@@ -13,3 +13,4 @@ Forming a multi-disciplinary agile team with the Foundation's own designers, lea
 
 :created_at: 2021-05-21 14:37:00 +0100
 :created_at: 2021-05-21 14:37:00 +0100
+:erb: true

--- a/soups/show-and-tell-events.snip.markdown
+++ b/soups/show-and-tell-events.snip.markdown
@@ -61,3 +61,4 @@ If you have any questions, please [get in touch][email-address].
 :updated_at: 2015-07-31 13:20:00 +01:00
 :layout: wiki-layout
 :page_title: Show and Tell Events
+:erb: true

--- a/soups/show-and-tell/show-and-tell-24.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-24.snip.markdown
@@ -138,3 +138,4 @@ I think it's great that Rob's tweaking the courses to try to give students a mor
 :updated_at: 2016-09-22 11:12:00 +01:00
 :page_title: Show and Tell 24
 :layout: show-and-tell-layout
+:erb: true

--- a/soups/show-and-tell/show-and-tell-25.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-25.snip.markdown
@@ -134,3 +134,4 @@ I can imagine adding the Brewfile to my dotfiles repo and potentially switching 
 :updated_at: 2016-10-14 17:20:00 +01:00
 :page_title: Show and Tell 25
 :layout: show-and-tell-layout
+:erb: true

--- a/soups/show-and-tell/show-and-tell-26.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-26.snip.markdown
@@ -130,3 +130,4 @@ There were lots of suggestions from the group, particularly around the idea of u
 :page_title: Show and Tell 26
 :extension: markdown
 :layout: show-and-tell-layout
+:erb: true

--- a/soups/show-and-tell/show-and-tell-27.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-27.snip.markdown
@@ -161,3 +161,4 @@ Please [get in touch][contact] if you're interested in joining us for the next S
 :page_title: Show and Tell 27
 :extension: markdown
 :layout: show-and-tell-layout
+:erb: true

--- a/soups/show-and-tell/show-and-tell-28.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-28.snip.markdown
@@ -154,3 +154,4 @@ Please [get in touch][contact] if you're interested in joining us for the next S
 :page_title: Show and Tell 28
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-29.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-29.snip.markdown
@@ -153,3 +153,4 @@ Please [get in touch][contact] if you're interested in joining us for the next S
 :page_title: Show and Tell 29
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-30.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-30.snip.markdown
@@ -186,3 +186,4 @@ though those slides for a while before heading downstairs for a drink.
 :page_title: Show and Tell 30
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-31.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-31.snip.markdown
@@ -123,3 +123,4 @@ Please [get in touch][contact] if you're interested in joining us for the next S
 :page_title: Show and Tell 31
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-32.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-32.snip.markdown
@@ -137,3 +137,4 @@ Please [get in touch][contact] if you're interested in joining us for the next S
 :page_title: Show and Tell 32
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-33.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-33.snip.markdown
@@ -115,3 +115,4 @@ We're hosting our 34th Show & Tell on Wednesday 12th July. Please [get in touch]
 :page_title: Show and Tell 33
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-34.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-34.snip.markdown
@@ -223,3 +223,4 @@ We're hosting our 35th Show & Tell on Wednesday 9th August. It's open to all so 
 :page_title: Show and Tell 34
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-35.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-35.snip.markdown
@@ -96,3 +96,4 @@ We're hosting our 36th Show & Tell on Wednesday, 13th September. It's open to al
 :page_title: Show and Tell 35
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-36.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-36.snip.markdown
@@ -195,3 +195,4 @@ We'll be hosting our 37th Show & Tell on Wednesday 11th October. It's open to al
 :page_title: Show and Tell 36
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-37.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-37.snip.markdown
@@ -118,3 +118,4 @@ We'll be hosting our 38th Show & Tell on Wednesday 8th November. It's open to al
 :page_title: Show and Tell 37
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-38.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-38.snip.markdown
@@ -94,3 +94,4 @@ Chris's Magic Eye demo and discussion reminded Ben of his [Hough Transform blog 
 :page_title: Show and Tell 38
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-39.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-39.snip.markdown
@@ -47,3 +47,4 @@ Ben spoke about an alternative way of teaching people about 3D modelling. Unfort
 :page_title: Show and Tell 39
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-40.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-40.snip.markdown
@@ -115,3 +115,4 @@ We'll be hosting our 41st Show & Tell in February. Please [get in touch][contact
 :page_title: Show and Tell 40
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-41.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-41.snip.markdown
@@ -105,3 +105,4 @@ Bash is building the app to help him learn React and to, ultimately, help him ge
 :page_title: Show and Tell 41
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-42.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-42.snip.markdown
@@ -53,3 +53,4 @@ Ben rounded off the evening for us by giving a quick demo and explanation of [Pa
 :page_title: Show and Tell 42
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-44.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-44.snip.markdown
@@ -94,3 +94,4 @@ We'll be hosting our 45th Show & Tell in June. Please [get in touch][contact] if
 :page_title: Show and Tell 44
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-46.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-46.snip.markdown
@@ -56,3 +56,4 @@ We'll be hosting our 47th Show & Tell in August. [Join our mailing list][contact
 :page_title: Show and Tell 46
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-5.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-5.snip.markdown
@@ -65,3 +65,4 @@ Although not technically part of the Show and Tell, [Murray][] was keen to show 
 :updated_at: 2014-09-15 17:30:00 +01:00
 :page_title: Show and Tell 5
 :layout: show-and-tell-layout
+:erb: true

--- a/soups/show-and-tell/show-and-tell-50.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-50.snip.markdown
@@ -82,3 +82,4 @@ We'll be hosting our [54th Show & Tell][] in tomorrow (Wed 17 Apr) night. Join o
 :page_title: Show and Tell 50 🍾
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-51.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-51.snip.markdown
@@ -72,3 +72,4 @@ James also demoed the handy "diff" command provided by the CDK command line inte
 :page_title: Show and Tell 51
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/show-and-tell/show-and-tell-53.snip.markdown
+++ b/soups/show-and-tell/show-and-tell-53.snip.markdown
@@ -60,3 +60,4 @@ The emoji search he developed is now integrated as part of the Mission Patch des
 :page_title: Show and Tell 53
 :layout: show-and-tell-layout
 :extension: markdown
+:erb: true

--- a/soups/start.snip.html
+++ b/soups/start.snip.html
@@ -12,3 +12,4 @@
 :is_page: true
 :updated_at: 2009-12-08 00:00:00 +00:00
 :created_at: 2009-12-01 00:00:00 +00:00
+:erb: true

--- a/soups/templates/week-nnn-links.snip.markdown
+++ b/soups/templates/week-nnn-links.snip.markdown
@@ -14,3 +14,4 @@ Your comments here. <%= by('chris-roos') %>
 :created_at: 2014-03-13 14:30:00 +00:00
 :updated_at: 2014-03-13 14:30:00 +00:00
 :page_title: Week NNN - Interesting links
+:erb: true

--- a/soups/we-are-a-coop.snip.markdown
+++ b/soups/we-are-a-coop.snip.markdown
@@ -8,3 +8,4 @@ We're proud to be a worker <span class="nowrap">co-operative</span> and a [membe
 
 :created_at: 2019-09-21 13:23:00 +0100
 :updated_at: 2019-09-21 13:23:00 +0100
+:erb: true

--- a/soups/weeklinks/week-218-links.snip.markdown
+++ b/soups/weeklinks/week-218-links.snip.markdown
@@ -61,3 +61,4 @@ I'm quite intrigued by Huginn which claims to be a self-hosted mixture of Yahoo!
 :created_at: 2013-03-18 10:32:00 +00:00
 :updated_at: 2013-03-18 10:32:00 +00:00
 :page_title: Monday Links - Week 218
+:erb: true

--- a/soups/weeklinks/week-219-links.snip.markdown
+++ b/soups/weeklinks/week-219-links.snip.markdown
@@ -73,3 +73,4 @@ As much as it currently pains me, I believe this is something that GFR are going
 :created_at: 2013-03-25 10:30:00 +00:00
 :updated_at: 2013-03-25 10:30:00 +00:00
 :page_title: Monday Links - Week 219
+:erb: true

--- a/soups/weeklinks/week-220-links.snip.markdown
+++ b/soups/weeklinks/week-220-links.snip.markdown
@@ -66,3 +66,4 @@ The entries for this year's [JS1k](http://js1k.com) competition are really outst
 :created_at: 2013-04-02 12:06:00 +00:00
 :updated_at: 2013-04-02 12:06:00 +00:00
 :page_title: Monday Links - Week 220
+:erb: true

--- a/soups/weeklinks/week-221-links.snip.markdown
+++ b/soups/weeklinks/week-221-links.snip.markdown
@@ -77,3 +77,4 @@ I don't know anything about [APL](http://en.wikipedia.org/wiki/APL_(programming_
 :created_at: 2013-04-08 10:46:00 +00:00
 :updated_at: 2013-04-08 10:46:00 +00:00
 :page_title: Monday Links - Week 221
+:erb: true

--- a/soups/weeklinks/week-222-links.snip.markdown
+++ b/soups/weeklinks/week-222-links.snip.markdown
@@ -47,3 +47,4 @@ I've tried a similar approach, sort-of, with encouraging more communication with
 :created_at: 2013-04-15 10:21:00 +01:00
 :updated_at: 2013-04-16 09:59:00 +01:00
 :page_title: Monday Links - Week 222
+:erb: true

--- a/soups/weeklinks/week-223-links.snip.markdown
+++ b/soups/weeklinks/week-223-links.snip.markdown
@@ -52,3 +52,4 @@ In my continuing quest to perfect my vim development environment, I'm really imp
 :created_at: 2013-04-22 10:31:00 +01:00
 :updated_at: 2013-04-22 10:31:00 +01:00
 :page_title: Monday Links - Week 223
+:erb: true

--- a/soups/weeklinks/week-224-links.snip.markdown
+++ b/soups/weeklinks/week-224-links.snip.markdown
@@ -39,3 +39,4 @@ You have been warned! <%= by('james-mead') %>
 :created_at: 2013-04-29 10:00:00 +01:00
 :updated_at: 2013-04-29 10:00:00 +01:00
 :page_title: Monday Links - Week 224
+:erb: true

--- a/soups/weeklinks/week-225-links.snip.markdown
+++ b/soups/weeklinks/week-225-links.snip.markdown
@@ -35,3 +35,4 @@ At [GFR](/) we've tried to minimise the amount of paper we use, and I like to th
 :created_at: 2013-05-06 10:00:00 +01:00
 :updated_at: 2013-05-06 14:30:00 +01:00
 :page_title: Monday Links - Week 225
+:erb: true

--- a/soups/weeklinks/week-226-links.snip.markdown
+++ b/soups/weeklinks/week-226-links.snip.markdown
@@ -40,3 +40,4 @@ This is long but I found it an interesting insight into the motivation behind so
 :created_at: 2013-05-13 10:00:00 +01:00
 :updated_at: 2013-05-13 10:00:00 +01:00
 :page_title: Monday Links - Week 226
+:erb: true

--- a/soups/weeklinks/week-227-links.snip.markdown
+++ b/soups/weeklinks/week-227-links.snip.markdown
@@ -33,3 +33,4 @@ I think this is a great description of what makes a good user story and how some
 :created_at: 2013-05-20 10:00:00 +01:00
 :updated_at: 2013-05-20 10:00:00 +01:00
 :page_title: Monday Links - Week 227
+:erb: true

--- a/soups/weeklinks/week-228-links.snip.markdown
+++ b/soups/weeklinks/week-228-links.snip.markdown
@@ -86,3 +86,4 @@ It's a couple of years old but I've only just come across this video and enjoyed
 :created_at: 2013-05-28 14:15:00 +01:00
 :updated_at: 2013-05-28 14:15:00 +01:00
 :page_title: Monday Links - Week 228
+:erb: true

--- a/soups/weeklinks/week-229-links.snip.markdown
+++ b/soups/weeklinks/week-229-links.snip.markdown
@@ -60,3 +60,4 @@ It's great to see another website making use of [Network Rail](http://www.networ
 :created_at: 2013-06-03 13:00:00 +01:00
 :updated_at: 2013-06-03 13:00:00 +01:00
 :page_title: Monday Links - Week 229
+:erb: true

--- a/soups/weeklinks/week-230-links.snip.markdown
+++ b/soups/weeklinks/week-230-links.snip.markdown
@@ -48,3 +48,4 @@ Bret Victor is amazing.  Pretty much [everything on his site](http://worrydream.
 :created_at: 2013-06-10 10:26:00 +01:00
 :updated_at: 2013-06-10 10:26:00 +01:00
 :page_title: Monday Links - Week 230
+:erb: true

--- a/soups/weeklinks/week-231-links.snip.markdown
+++ b/soups/weeklinks/week-231-links.snip.markdown
@@ -45,3 +45,4 @@ I came across this recently after trying to find a similar tool that I'd previou
 :created_at: 2013-06-17 17:00:00 +01:00
 :updated_at: 2013-06-17 17:00:00 +01:00
 :page_title: Monday Links - Week 231
+:erb: true

--- a/soups/weeklinks/week-232-links.snip.markdown
+++ b/soups/weeklinks/week-232-links.snip.markdown
@@ -39,3 +39,4 @@ I bumped into [Matt Wynne](http://mattwynne.net) on a Sleeper from London to Sco
 :created_at: 2013-06-24 10:00:00 +01:00
 :updated_at: 2013-06-24 10:00:00 +01:00
 :page_title: Monday Links - Week 232
+:erb: true

--- a/soups/weeklinks/week-233-links.snip.markdown
+++ b/soups/weeklinks/week-233-links.snip.markdown
@@ -39,3 +39,4 @@ I've seen this problem a few times when playing with XmlHttpRequest, most recent
 :created_at: 2013-07-01 14:00:00 +01:00
 :updated_at: 2013-07-01 14:00:00 +01:00
 :page_title: Monday Links - Week 233
+:erb: true

--- a/soups/weeklinks/week-234-links.snip.markdown
+++ b/soups/weeklinks/week-234-links.snip.markdown
@@ -54,3 +54,4 @@ I have 83,156 emails in my *personal* email account, spanning from the 1st of Ap
 :created_at: 2013-07-08 15:30:00 +01:00
 :updated_at: 2013-07-08 15:30:00 +01:00
 :page_title: Monday Links - Week 234
+:erb: true

--- a/soups/weeklinks/week-235-links.snip.markdown
+++ b/soups/weeklinks/week-235-links.snip.markdown
@@ -33,3 +33,4 @@ I find the work being done in this area really interesting and it really motivat
 :created_at: 2013-07-15 15:00:00 +01:00
 :updated_at: 2013-07-15 15:00:00 +01:00
 :page_title: Monday Links - Week 235
+:erb: true

--- a/soups/weeklinks/week-236-links.snip.markdown
+++ b/soups/weeklinks/week-236-links.snip.markdown
@@ -37,3 +37,4 @@ Another of the strong themes at LSRC was pair programming, and in particular rem
 :created_at: 2013-07-22 13:00:00 +01:00
 :updated_at: 2013-07-22 13:00:00 +01:00
 :page_title: Monday Links - Week 236
+:erb: true

--- a/soups/weeklinks/week-237-links.snip.markdown
+++ b/soups/weeklinks/week-237-links.snip.markdown
@@ -53,3 +53,4 @@ Striking a balance between polishing features and shipping them fast is a tough 
 :created_at: 2013-07-29 13:00:00 +01:00
 :updated_at: 2013-07-29 13:00:00 +01:00
 :page_title: Monday Links - Week 237
+:erb: true

--- a/soups/weeklinks/week-238-links.snip.markdown
+++ b/soups/weeklinks/week-238-links.snip.markdown
@@ -57,3 +57,4 @@ The ultimate sock-pairing machine? Apparently this uses RFIDs in your socks and 
 :created_at: 2013-08-05 13:00:00 +01:00
 :updated_at: 2013-08-05 13:00:00 +01:00
 :page_title: Monday Links - Week 238
+:erb: true

--- a/soups/weeklinks/week-239-links.snip.markdown
+++ b/soups/weeklinks/week-239-links.snip.markdown
@@ -58,3 +58,4 @@ I've been using Stringer as my RSS reader since Google Reader shut up shop. It's
 :created_at: 2013-08-12 13:00:00 +01:00
 :updated_at: 2013-08-12 13:00:00 +01:00
 :page_title: Monday Links - Week 239
+:erb: true

--- a/soups/weeklinks/week-240-links.snip.markdown
+++ b/soups/weeklinks/week-240-links.snip.markdown
@@ -27,3 +27,4 @@ It apparently matches any word in /usr/share/dict/words.  Do not use this for an
 :created_at: 2013-08-19 13:00:00 +01:00
 :updated_at: 2013-08-19 13:00:00 +01:00
 :page_title: Monday Links - Week 240
+:erb: true

--- a/soups/weeklinks/week-241-links.snip.markdown
+++ b/soups/weeklinks/week-241-links.snip.markdown
@@ -36,3 +36,4 @@ I'm also interested in pub/sub listener techniques for decoupling your business 
 :created_at: 2013-08-27 13:00:00 +01:00
 :updated_at: 2013-08-27 13:00:00 +01:00
 :page_title: Monday Links - Week 241
+:erb: true

--- a/soups/weeklinks/week-242-links.snip.markdown
+++ b/soups/weeklinks/week-242-links.snip.markdown
@@ -51,3 +51,4 @@ I've never quite understood why feed readers (well, the ones I've used at least)
 :created_at: 2013-09-02 13:00:00 +01:00
 :updated_at: 2013-09-02 13:00:00 +01:00
 :page_title: Monday Links - Week 242
+:erb: true

--- a/soups/weeklinks/week-243-links.snip.markdown
+++ b/soups/weeklinks/week-243-links.snip.markdown
@@ -29,3 +29,4 @@ Talking of Kent Beck, I'm attending this talk by him at Facebook, London, tomorr
 :created_at: 2013-09-09 13:00:00 +01:00
 :updated_at: 2013-09-09 13:00:00 +01:00
 :page_title: Monday Links - Week 243
+:erb: true

--- a/soups/weeklinks/week-244-links.snip.markdown
+++ b/soups/weeklinks/week-244-links.snip.markdown
@@ -54,3 +54,4 @@ A pretty-long but very comprehesive writeup of one person selling the product th
 :created_at: 2013-09-16 16:30:00 +01:00
 :updated_at: 2013-09-16 16:30:00 +01:00
 :page_title: Monday Links - Week 244
+:erb: true

--- a/soups/weeklinks/week-245-links.snip.markdown
+++ b/soups/weeklinks/week-245-links.snip.markdown
@@ -39,3 +39,4 @@ Being able to extend an `ActiveRecord::Relation` object with custom scopes looks
 :created_at: 2013-09-23 13:05:00 +01:00
 :updated_at: 2013-09-23 13:05:00 +01:00
 :page_title: Monday Links - Week 245
+:erb: true

--- a/soups/weeklinks/week-246-links.snip.markdown
+++ b/soups/weeklinks/week-246-links.snip.markdown
@@ -34,3 +34,4 @@ While I agree with the problems outlined, I'm far from convinced using a calenda
 :created_at: 2013-09-30 15:00:00 +01:00
 :updated_at: 2013-09-30 15:00:00 +01:00
 :page_title: Monday Links - Week 246
+:erb: true

--- a/soups/weeklinks/week-247-links.snip.markdown
+++ b/soups/weeklinks/week-247-links.snip.markdown
@@ -48,3 +48,4 @@ These little cubes have a flywheel inside which can reach speeds of 20,000 revol
 :created_at: 2013-10-07 14:00:00 +01:00
 :updated_at: 2013-10-07 14:00:00 +01:00
 :page_title: Monday Links - Week 247
+:erb: true

--- a/soups/weeklinks/week-248-links.snip.markdown
+++ b/soups/weeklinks/week-248-links.snip.markdown
@@ -29,3 +29,4 @@ A Ruby mocking & stubbing library made in Peru and sharing the [sobriquet](http:
 :created_at: 2013-10-15 10:00:00 +01:00
 :updated_at: 2013-10-15 10:00:00 +01:00
 :page_title: Monday Links - Week 248
+:erb: true

--- a/soups/weeklinks/week-249-links.snip.markdown
+++ b/soups/weeklinks/week-249-links.snip.markdown
@@ -34,3 +34,4 @@ Joel [pointed me](https://twitter.com/joelchippindale/status/391217996687233024)
 :created_at: 2013-10-21 19:52:00 +01:00
 :updated_at: 2013-10-21 19:52:00 +01:00
 :page_title: Monday Links - Week 249
+:erb: true

--- a/soups/weeklinks/week-250-links.snip.markdown
+++ b/soups/weeklinks/week-250-links.snip.markdown
@@ -29,3 +29,4 @@ I came across the term Hyperlapse after watching this excellent "[Louisville In 
 :created_at: 2013-10-28 18:30:00 +00:00
 :updated_at: 2013-10-28 18:30:00 +00:00
 :page_title: Monday Links - Week 250
+:erb: true

--- a/soups/weeklinks/week-251-links.snip.markdown
+++ b/soups/weeklinks/week-251-links.snip.markdown
@@ -40,3 +40,4 @@ I've never been sold on the oocss approach and this post contains some compellin
 :created_at: 2013-11-05 10:00:00 +00:00
 :updated_at: 2013-11-05 10:00:00 +00:00
 :page_title: Monday Links - Week 251
+:erb: true

--- a/soups/weeklinks/week-252-links.snip.markdown
+++ b/soups/weeklinks/week-252-links.snip.markdown
@@ -48,3 +48,4 @@ Michael works through a simple example using Ruby. <%= by('james-mead') %>
 :created_at: 2013-11-11 14:00:00 +00:00
 :updated_at: 2013-11-11 14:00:00 +00:00
 :page_title: Monday Links - Week 252
+:erb: true

--- a/soups/weeklinks/week-253-links.snip.markdown
+++ b/soups/weeklinks/week-253-links.snip.markdown
@@ -42,3 +42,4 @@ I really like this idea as a simpler alternative to Github Pages. My only concer
 :created_at: 2013-11-18 18:44:00 +00:00
 :updated_at: 2013-11-18 18:44:00 +00:00
 :page_title: Monday Links - Week 253
+:erb: true

--- a/soups/weeklinks/week-254-links.snip.markdown
+++ b/soups/weeklinks/week-254-links.snip.markdown
@@ -41,3 +41,4 @@ I've been really interested to hear [Chris Lowis](https://twitter.com/chrislowis
 :created_at: 2013-11-26 14:00:00 +00:00
 :updated_at: 2013-11-26 14:00:00 +00:00
 :page_title: Monday Links - Week 254
+:erb: true

--- a/soups/weeklinks/week-255-links.snip.markdown
+++ b/soups/weeklinks/week-255-links.snip.markdown
@@ -29,3 +29,4 @@ I enjoyed reading this article by Alan Francis and being reminded of the corresp
 :created_at: 2013-12-03 14:00:00 +00:00
 :updated_at: 2013-12-03 14:00:00 +00:00
 :page_title: Monday Links - Week 255
+:erb: true

--- a/soups/weeklinks/week-256-links.snip.markdown
+++ b/soups/weeklinks/week-256-links.snip.markdown
@@ -34,3 +34,4 @@ It's really useful to be able to preview files containing Markdown, Git diffs, C
 :created_at: 2013-12-12 11:43:00 +00:00
 :updated_at: 2013-12-12 11:43:00 +00:00
 :page_title: Monday Links - Week 256
+:erb: true

--- a/soups/weeklinks/week-257-links.snip.markdown
+++ b/soups/weeklinks/week-257-links.snip.markdown
@@ -33,3 +33,4 @@ I've previously read a little about [Morning Star](http://morningstarco.com/)'s 
 :created_at: 2013-12-16 15:35:00 +00:00
 :updated_at: 2013-12-16 15:35:00 +00:00
 :page_title: Monday Links - Week 257
+:erb: true

--- a/soups/weeklinks/week-261-links.snip.markdown
+++ b/soups/weeklinks/week-261-links.snip.markdown
@@ -58,3 +58,4 @@ There's not much information to go on, but this open-source mobile phone sounds 
 :created_at: 2014-01-15 15:00:00 +00:00
 :updated_at: 2014-01-15 15:00:00 +00:00
 :page_title: Wednesday Links - Week 261
+:erb: true

--- a/soups/weeklinks/week-262-links.snip.markdown
+++ b/soups/weeklinks/week-262-links.snip.markdown
@@ -47,3 +47,4 @@ I came across this tutorial by MIT via [How-To: Shrinkify Your Arduino Projects]
 :created_at: 2014-01-22 18:00:00 +00:00
 :updated_at: 2014-01-22 18:00:00 +00:00
 :page_title: Wednesday Links - Week 262
+:erb: true

--- a/soups/weeklinks/week-263-links.snip.markdown
+++ b/soups/weeklinks/week-263-links.snip.markdown
@@ -48,3 +48,4 @@ I think [Ben Griffiths](https://twitter.com/beng) made something like this. <%= 
 :created_at: 2014-01-31 08:00:00 +00:00
 :updated_at: 2014-01-31 08:00:00 +00:00
 :page_title: Week 263 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-264-links.snip.markdown
+++ b/soups/weeklinks/week-264-links.snip.markdown
@@ -54,3 +54,4 @@ Martin Fowler [recently blogged](http://martinfowler.com/snips/201401291615.html
 :created_at: 2014-02-06 12:00:00 +00:00
 :updated_at: 2014-02-06 12:00:00 +00:00
 :page_title: Week 264 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-265-links.snip.markdown
+++ b/soups/weeklinks/week-265-links.snip.markdown
@@ -43,3 +43,4 @@ I like to think this is at the heart of the way we operate at [GFR](/). <%= by('
 :created_at: 2014-02-13 12:25:00 +00:00
 :updated_at: 2014-02-13 12:25:00 +00:00
 :page_title: Week 265 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-266-links.snip.markdown
+++ b/soups/weeklinks/week-266-links.snip.markdown
@@ -38,3 +38,4 @@ I'm sure I've wanted to be able to do this in the past; and now I know how! A to
 :created_at: 2014-02-19 17:41:00 +00:00
 :updated_at: 2014-02-19 17:41:00 +00:00
 :page_title: Week 266 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-267-links.snip.markdown
+++ b/soups/weeklinks/week-267-links.snip.markdown
@@ -43,3 +43,4 @@ I really enjoyed the most recent Little Schemer book club meeting. We hooked up 
 :created_at: 2014-02-26 16:50:00 +00:00
 :updated_at: 2014-02-26 16:50:00 +00:00
 :page_title: Week 267 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-268-links.snip.markdown
+++ b/soups/weeklinks/week-268-links.snip.markdown
@@ -61,3 +61,4 @@ And
 :created_at: 2014-03-06 11:30:00 +00:00
 :updated_at: 2014-03-06 11:30:00 +00:00
 :page_title: Week 268 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-269-links.snip.markdown
+++ b/soups/weeklinks/week-269-links.snip.markdown
@@ -58,3 +58,4 @@ The GitHub blame view has links in the left hand margin to the last commit where
 :created_at: 2014-03-13 14:30:00 +00:00
 :updated_at: 2014-03-13 14:30:00 +00:00
 :page_title: Week 269 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-270-links.snip.markdown
+++ b/soups/weeklinks/week-270-links.snip.markdown
@@ -45,3 +45,4 @@ This is a great article by [Jeremy Keith][]. I'll give you a little taster but r
 :created_at: 2014-03-21 11:00:00 +00:00
 :updated_at: 2014-03-21 11:00:00 +00:00
 :page_title: Week 270 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-272-links.snip.markdown
+++ b/soups/weeklinks/week-272-links.snip.markdown
@@ -47,3 +47,4 @@ I found this pretty interesting. It turns out that the ASCII character set conta
 :created_at: 2014-04-03 13:00:00 +10:00
 :updated_at: 2014-04-03 13:00:00 +10:00
 :page_title: Week 272 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-273-links.snip.markdown
+++ b/soups/weeklinks/week-273-links.snip.markdown
@@ -63,3 +63,4 @@ This article makes Twitter's [Flight framework](http://twitter.github.io/flight/
 :created_at: 2014-04-11 16:00:00 +10:00
 :updated_at: 2014-04-11 16:00:00 +10:00
 :page_title: Week 273 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-274-links.snip.markdown
+++ b/soups/weeklinks/week-274-links.snip.markdown
@@ -29,3 +29,4 @@ I'm sorry that this is a bit dull, but we've been doing a lot of work around vid
 :created_at: 2014-04-16 17:30:00 +00:00
 :updated_at: 2014-04-16 17:30:00 +00:00
 :page_title: Week 274 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-275-links.snip.markdown
+++ b/soups/weeklinks/week-275-links.snip.markdown
@@ -34,3 +34,4 @@ This is a impressive Chrome extension which effectively OCRs images and document
 :created_at: 2014-04-24 11:00:00 +00:00
 :updated_at: 2014-04-24 11:00:00 +00:00
 :page_title: Week 275 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-277-links.snip.markdown
+++ b/soups/weeklinks/week-277-links.snip.markdown
@@ -68,3 +68,4 @@ I've definitely felt the pain of having a long email exchange in order to arrang
 :created_at: 2014-05-08 14:00:00 +00:00
 :updated_at: 2014-05-08 14:00:00 +00:00
 :page_title: Week 277 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-278-links.snip.markdown
+++ b/soups/weeklinks/week-278-links.snip.markdown
@@ -69,3 +69,4 @@ In this article the [Zooniverse](https://www.zooniverse.org/) gang write about a
 :created_at: 2014-05-15 17:00:00 +00:00
 :updated_at: 2014-05-16 11:00:00 +00:00
 :page_title: Week 278 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-279-links.snip.markdown
+++ b/soups/weeklinks/week-279-links.snip.markdown
@@ -46,3 +46,4 @@ A neat internet-conected compass-like device built by Tom Armitage which always 
 :created_at: 2014-05-24 19:50:00 +00:00
 :updated_at: 2014-05-24 19:50:00 +00:00
 :page_title: Week 279 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-281-links.snip.markdown
+++ b/soups/weeklinks/week-281-links.snip.markdown
@@ -49,3 +49,4 @@ Other commenters mention the [Dust-Me Selectors](https://addons.mozilla.org/en-U
 :created_at: 2014-06-05 15:00:00 +01:00
 :updated_at: 2014-06-05 15:00:00 +01:00
 :page_title: Week 281 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-283-links.snip.markdown
+++ b/soups/weeklinks/week-283-links.snip.markdown
@@ -77,3 +77,4 @@ I noticed that [James A][] has promoted [Harmonia][] on there and it looks like 
 :created_at: 2014-06-18 13:00:00 +01:00
 :updated_at: 2014-06-18 13:00:00 +01:00
 :page_title: Week 283 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-284-links.snip.markdown
+++ b/soups/weeklinks/week-284-links.snip.markdown
@@ -68,3 +68,4 @@ Actually, it's double congratulations because they've just [announced that Makie
 :created_at: 2014-06-26 14:21:00 +01:00
 :updated_at: 2014-06-26 14:21:00 +01:00
 :page_title: Week 284 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-285-links.snip.markdown
+++ b/soups/weeklinks/week-285-links.snip.markdown
@@ -57,3 +57,4 @@ This sounds really interesting: Using Indieweb ideas/software to allow students 
 :created_at: 2014-07-03 13:00:00 +01:00
 :updated_at: 2014-07-03 13:00:00 +01:00
 :page_title: Week 285 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-286-links.snip.markdown
+++ b/soups/weeklinks/week-286-links.snip.markdown
@@ -46,3 +46,4 @@ This seems like quite a neat way of prototyping a data driven website. You give 
 :created_at: 2014-07-10 15:00:00 +01:00
 :updated_at: 2014-07-10 15:00:00 +01:00
 :page_title: Week 286 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-287-links.snip.markdown
+++ b/soups/weeklinks/week-287-links.snip.markdown
@@ -50,3 +50,4 @@ I'm not sure how seriously we considered setting up an [Industrial & Provident S
 :created_at: 2014-07-17 13:34:00 +01:00
 :updated_at: 2014-07-17 13:34:00 +01:00
 :page_title: Week 287 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-288-links.snip.markdown
+++ b/soups/weeklinks/week-288-links.snip.markdown
@@ -79,3 +79,4 @@ Apparently the BBC are trialling "country" and "topic" pages like the ones on [I
 :created_at: 2014-07-24 15:00:00 +01:00
 :updated_at: 2014-07-24 15:00:00 +01:00
 :page_title: Week 288 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-289-links.snip.markdown
+++ b/soups/weeklinks/week-289-links.snip.markdown
@@ -75,3 +75,4 @@ Amy (my partner) and Emily have been collecting research for their [Minimum Viab
 :created_at: 2014-07-31 11:30:00 +01:00
 :updated_at: 2014-07-31 11:30:00 +01:00
 :page_title: Week 289 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-290-links.snip.markdown
+++ b/soups/weeklinks/week-290-links.snip.markdown
@@ -51,3 +51,4 @@ Although it's a bit US-centric, I found this article about the economic benefits
 :created_at: 2014-08-07 16:27:00 +01:00
 :updated_at: 2014-08-07 16:27:00 +01:00
 :page_title: Week 290 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-291-links.snip.markdown
+++ b/soups/weeklinks/week-291-links.snip.markdown
@@ -39,3 +39,4 @@ This looks interesting. They appear to have quite a lot of regularly updated con
 :created_at: 2014-08-14 12:00:00 +01:00
 :updated_at: 2014-08-14 12:00:00 +01:00
 :page_title: Week 291 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-292-links.snip.markdown
+++ b/soups/weeklinks/week-292-links.snip.markdown
@@ -52,3 +52,4 @@ I really enjoyed reading this post shared by [Paul](http://po-ru.com/). The titl
 :created_at: 2014-08-21 15:30:00 +00:00
 :updated_at: 2014-08-21 15:30:00 +00:00
 :page_title: Week 292 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-294-links.snip.markdown
+++ b/soups/weeklinks/week-294-links.snip.markdown
@@ -39,3 +39,4 @@ Many congratulations to [Tom Hall][] on his successfull kickstarter project: Tom
 :created_at: 2014-09-04 15:30:00 +01:00
 :updated_at: 2014-09-04 15:30:00 +01:00
 :page_title: Week 294 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-295-links.snip.markdown
+++ b/soups/weeklinks/week-295-links.snip.markdown
@@ -64,3 +64,4 @@ This looks interesting - I'll have to give it a go if/when we do more work on th
 :created_at: 2014-09-11 14:22:00 +00:00
 :updated_at: 2014-09-11 14:22:00 +00:00
 :page_title: Week 295 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-296-links.snip.markdown
+++ b/soups/weeklinks/week-296-links.snip.markdown
@@ -57,3 +57,4 @@ As the article suggests, we shouldn't assume that more automation is always bett
 :created_at: 2014-09-19 11:15:00 +00:00
 :updated_at: 2014-09-19 11:15:00 +00:00
 :page_title: Week 296 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-297-links.snip.markdown
+++ b/soups/weeklinks/week-297-links.snip.markdown
@@ -43,3 +43,4 @@ Tantek has done a great job of documenting the achievements of IndieWebCamp UK. 
 :created_at: 2014-09-26 12:34:00 +00:00
 :updated_at: 2014-09-26 12:34:00 +00:00
 :page_title: Week 297 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-298-links.snip.markdown
+++ b/soups/weeklinks/week-298-links.snip.markdown
@@ -48,3 +48,4 @@ I usually try to link to a specific section/paragraph on a page if I can. In fac
 :created_at: 2014-10-03 09:52:00 +00:00
 :updated_at: 2014-10-03 09:52:00 +00:00
 :page_title: Week 298 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-300-links.snip.markdown
+++ b/soups/weeklinks/week-300-links.snip.markdown
@@ -60,3 +60,4 @@ I haven't tried it but really like the look of this app. I collect quite a bit o
 :created_at: 2014-10-15 14:39:00 +00:00
 :updated_at: 2014-10-15 14:39:00 +00:00
 :page_title: Week 300 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-302-links.snip.markdown
+++ b/soups/weeklinks/week-302-links.snip.markdown
@@ -66,3 +66,4 @@ This made me laugh. It's a browser plugin that automatically clicks on *all* adv
 :created_at: 2014-10-31 17:00:00 +00:00
 :updated_at: 2014-10-31 17:00:00 +00:00
 :page_title: Week 302 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-304-links.snip.markdown
+++ b/soups/weeklinks/week-304-links.snip.markdown
@@ -52,3 +52,4 @@ The folks at [Known][] have created this useful directory containing instruction
 :created_at: 2014-11-12 16:52:00 +00:00
 :updated_at: 2014-11-12 16:52:00 +00:00
 :page_title: Week 304 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-306-links.snip.markdown
+++ b/soups/weeklinks/week-306-links.snip.markdown
@@ -54,3 +54,4 @@ The [Deserter][] has recently become one of my favourite blogs (thanks, [Paul B]
 :created_at: 2014-11-25 15:25:00 +00:00
 :updated_at: 2014-11-25 15:25:00 +00:00
 :page_title: Week 306 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-310-links.snip.markdown
+++ b/soups/weeklinks/week-310-links.snip.markdown
@@ -50,3 +50,4 @@ This e-Money payment card by Contis seems to offer an individual sort-code and a
 :created_at: 2014-12-22 12:15:00 +00:00
 :updated_at: 2014-12-22 12:15:00 +00:00
 :page_title: Week 310 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-313-links.snip.markdown
+++ b/soups/weeklinks/week-313-links.snip.markdown
@@ -34,3 +34,4 @@ An impressive visualisation of a rock-climbing route up El Capitan in Yosemite N
 :created_at: 2015-01-12 16:20:00 +00:00
 :updated_at: 2015-01-12 16:20:00 +00:00
 :page_title: Week 313 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-316-links.snip.markdown
+++ b/soups/weeklinks/week-316-links.snip.markdown
@@ -53,3 +53,4 @@ A platform for deploying and running web crawlers. The [Crawlera](http://scrapin
 :created_at: 2015-02-04 14:38:00 +00:00
 :updated_at: 2015-02-04 14:38:00 +00:00
 :page_title: Week 316 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-318-links.snip.markdown
+++ b/soups/weeklinks/week-318-links.snip.markdown
@@ -59,3 +59,4 @@ This amused me. [Deloitte's Digital Maturity survey](http://www.deloittedigital.
 :created_at: 2015-02-19 15:37:00 +00:00
 :updated_at: 2015-02-19 15:37:00 +00:00
 :page_title: Week 318 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-320-links.snip.markdown
+++ b/soups/weeklinks/week-320-links.snip.markdown
@@ -51,3 +51,4 @@ I enjoy reading Little Big Details and was pleased to see them include [GOV.UK's
 :created_at: 2015-03-11 10:30:00 +00:00
 :updated_at: 2015-03-11 10:30:00 +00:00
 :page_title: Week 320 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-322-links.snip.markdown
+++ b/soups/weeklinks/week-322-links.snip.markdown
@@ -65,3 +65,4 @@ I'm really pleased to see that Ryan and Dietrich have released their [Meat Club 
 :created_at: 2015-03-24 10:42:00 +00:00
 :updated_at: 2015-03-24 10:42:00 +00:00
 :page_title: Week 322 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-324-links.snip.markdown
+++ b/soups/weeklinks/week-324-links.snip.markdown
@@ -78,3 +78,4 @@ I came across it via a [tweet from Kent Beck][] which suggests this is a good mo
 :created_at: 2015-04-01 10:42:00 +00:00
 :updated_at: 2015-04-07 16:30:00 +00:00
 :page_title: Week 324 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-328-links.snip.markdown
+++ b/soups/weeklinks/week-328-links.snip.markdown
@@ -40,3 +40,4 @@ The superb footage in this video was filmed from a [DJI Phantom 2][] drone with 
 :created_at: 2015-05-01 12:30:00 +01:00
 :updated_at: 2015-05-01 15:30:00 +01:00
 :page_title: Week 328 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-332-links.snip.markdown
+++ b/soups/weeklinks/week-332-links.snip.markdown
@@ -61,3 +61,4 @@ It's great to see FutureLearn start to open up some of their course content to p
 :created_at: 2015-05-29 15:47:00 +00:00
 :updated_at: 2015-05-29 15:47:00 +00:00
 :page_title: Week 332 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-334-links.snip.markdown
+++ b/soups/weeklinks/week-334-links.snip.markdown
@@ -51,3 +51,4 @@ This pair of videos about which way water goes down the plug-hole in different h
 :created_at: 2015-06-12 12:00:00 +00:00
 :updated_at: 2015-06-12 16:30:00 +00:00
 :page_title: Week 334 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-338-links.snip.markdown
+++ b/soups/weeklinks/week-338-links.snip.markdown
@@ -84,3 +84,4 @@ The other day, [Tom S](http://codon.com/) mentioned the `exec` "command" in the 
 :created_at: 2015-07-10 11:45:00 +00:00
 :updated_at: 2015-07-10 15:45:00 +00:00
 :page_title: Week 338 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-340-links.snip.markdown
+++ b/soups/weeklinks/week-340-links.snip.markdown
@@ -47,3 +47,4 @@ I think these are awesome :-) <%= by('chris-roos') %>
 :created_at: 2015-07-24 15:20:00 +01:00
 :updated_at: 2015-07-24 15:20:00 +01:00
 :page_title: Week 340 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-342-links.snip.markdown
+++ b/soups/weeklinks/week-342-links.snip.markdown
@@ -72,3 +72,4 @@ The blog post suggests that the data comes from people that have activated Locat
 :created_at: 2015-08-07 13:12:00 +01:00
 :updated_at: 2015-08-07 13:12:00 +01:00
 :page_title: Week 342 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-344-links.snip.markdown
+++ b/soups/weeklinks/week-344-links.snip.markdown
@@ -64,3 +64,4 @@ I linked to [Google's Plus Codes][pluscodes] in our [links for week 332][week-33
 :created_at: 2015-08-21 15:25:00 +01:00
 :updated_at: 2015-08-21 15:25:00 +01:00
 :page_title: Week 344 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-350-links.snip.markdown
+++ b/soups/weeklinks/week-350-links.snip.markdown
@@ -72,3 +72,4 @@ A little inspirational link to finish with: Read an interview with 80 year old H
 :created_at: 2015-10-02 13:58:00 +01:00
 :updated_at: 2015-10-02 13:58:00 +01:00
 :page_title: Week 350 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-354-links.snip.markdown
+++ b/soups/weeklinks/week-354-links.snip.markdown
@@ -69,3 +69,4 @@ I was impressed to see this command line tool which [makes it very easy][lets-en
 :created_at: 2015-10-29 16:15:00 +00:00
 :updated_at: 2015-10-29 16:15:00 +00:00
 :page_title: Week 354 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-356-links.snip.markdown
+++ b/soups/weeklinks/week-356-links.snip.markdown
@@ -59,3 +59,4 @@ This was the improvised adventure story tweeted by [Melinda](https://missgeeky.c
 :created_at: 2015-11-10 16:30:00 +00:00
 :updated_at: 2015-11-10 16:30:00 +00:00
 :page_title: Week 356 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-367-links.snip.markdown
+++ b/soups/weeklinks/week-367-links.snip.markdown
@@ -88,3 +88,4 @@ An amazing bit of skiing! <%= by('james-mead') %>
 :created_at: 2016-01-28 08:00:00 +13:00
 :updated_at: 2016-01-28 08:00:00 +13:00
 :page_title: Week 367 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-368-links.snip.markdown
+++ b/soups/weeklinks/week-368-links.snip.markdown
@@ -47,3 +47,4 @@ This 7" touchscreen looks great and is priced from [a very reasonable £52][rpi-
 :created_at: 2016-02-02 14:33:00 +01:00
 :updated_at: 2016-02-04 11:05:00 +01:00
 :page_title: Week 368 - Interesting links
+:erb: true

--- a/soups/weeklinks/week-394-links.snip.markdown
+++ b/soups/weeklinks/week-394-links.snip.markdown
@@ -49,3 +49,4 @@ This beautiful magazine is produced by a friend of a friend. The couple of issue
 :author: james-mead
 :page_title: Week 394 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-400-links.snip.markdown
+++ b/soups/weeklinks/week-400-links.snip.markdown
@@ -61,3 +61,4 @@ I loved reading this article by a digital nomad, Thomas Buckley-Houston, who's b
 :author: chris-roos
 :page_title: Week 400 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-402-links.snip.markdown
+++ b/soups/weeklinks/week-402-links.snip.markdown
@@ -33,3 +33,4 @@ I had no idea that XPath selectors are built-in to Chrome's Developer Tools cons
 :author: james-mead
 :page_title: Week 402 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-404-links.snip.markdown
+++ b/soups/weeklinks/week-404-links.snip.markdown
@@ -73,3 +73,4 @@ I love this little time-lapse of earth. A little research about the footage lead
 :author: james-mead
 :page_title: Week 404 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-406-links.snip.markdown
+++ b/soups/weeklinks/week-406-links.snip.markdown
@@ -27,3 +27,4 @@ I'm not really sure why I find this so amusing. <%= by('chris-roos') %>
 :author: chris-roos
 :page_title: Week 406 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-408-links.snip.markdown
+++ b/soups/weeklinks/week-408-links.snip.markdown
@@ -31,3 +31,4 @@ I really like this idea of visualising software as interactive, navigable 3D cit
 :author: james-mead
 :page_title: Week 408 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-412-links.snip.markdown
+++ b/soups/weeklinks/week-412-links.snip.markdown
@@ -51,3 +51,4 @@ I came across this tool in the [Ruby Together progress report for December][]. A
 :author: james-mead
 :page_title: Week 412 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-414-links.snip.markdown
+++ b/soups/weeklinks/week-414-links.snip.markdown
@@ -39,3 +39,4 @@ Someone has started trying to build a 32-bit CPU out of 74-series logic chips. T
 :author: james-mead
 :page_title: Week 414 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-416-links.snip.markdown
+++ b/soups/weeklinks/week-416-links.snip.markdown
@@ -43,3 +43,4 @@ This handy looking library allows you to use a text-based syntax to generate dia
 :author: james-mead
 :page_title: Week 416 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-418-links.snip.markdown
+++ b/soups/weeklinks/week-418-links.snip.markdown
@@ -28,3 +28,4 @@ I quite like this site that aggregates public apologies made by various transpor
 :author: chris-roos
 :page_title: Week 418 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-424-links.snip.markdown
+++ b/soups/weeklinks/week-424-links.snip.markdown
@@ -38,3 +38,4 @@ I heard about this online & print magazine in one of the sessions at the [Open 2
 :author: chris-lowis
 :page_title: Week 424 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-426-links.snip.markdown
+++ b/soups/weeklinks/week-426-links.snip.markdown
@@ -44,3 +44,4 @@ This paid-for service sounds as if it's supposed to offer a better experience th
 :author: chris-lowis
 :page_title: Week 426 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-428-links.snip.markdown
+++ b/soups/weeklinks/week-428-links.snip.markdown
@@ -68,3 +68,4 @@ This project is part of [Explorable Explanations][], a movement to make learning
 :author: james-mead
 :page_title: Week 428 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-432-links.snip.markdown
+++ b/soups/weeklinks/week-432-links.snip.markdown
@@ -31,3 +31,4 @@ I was also fascinated by this video [19 mins] which Ben mentioned. It's amazing 
 :author: james-mead
 :page_title: Week 432 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-434-links.snip.markdown
+++ b/soups/weeklinks/week-434-links.snip.markdown
@@ -55,3 +55,4 @@ This is a re-imagining of the ZX Spectrum using new hardware, but still fully co
 :author: chris-lowis
 :page_title: Week 434 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-438-links.snip.markdown
+++ b/soups/weeklinks/week-438-links.snip.markdown
@@ -60,3 +60,4 @@ This is a bit of a wacky experiment which borrows some of the ideas from [Scuttl
 :author: chris-roos
 :page_title: Week 438 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-440-links.snip.markdown
+++ b/soups/weeklinks/week-440-links.snip.markdown
@@ -48,3 +48,4 @@ example in pull requests) self-contained. <%= by('chris-lowis') %>
 :author: james-mead
 :page_title: Week 440 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-442-links.snip.markdown
+++ b/soups/weeklinks/week-442-links.snip.markdown
@@ -63,3 +63,4 @@ I really appreciate that [Monzo's transparency](https://monzo.com/transparency/)
 :author: james-mead
 :page_title: Week 442 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-444-links.snip.markdown
+++ b/soups/weeklinks/week-444-links.snip.markdown
@@ -23,3 +23,4 @@ David Marland built this site to provide alerts when London's tube network has d
 :author: chris-roos
 :page_title: Week 444 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-446-links.snip.markdown
+++ b/soups/weeklinks/week-446-links.snip.markdown
@@ -42,3 +42,4 @@ I haven't had a chance to read it yet, but I was pleased to see that [Rob Chatle
 :author: chris-roos
 :page_title: Week 446 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-448-links.snip.markdown
+++ b/soups/weeklinks/week-448-links.snip.markdown
@@ -48,3 +48,4 @@ A fun article from Rasmus Bååth where he uses probabilistic reasoning, experim
 :author: chris-lowis
 :page_title: Week 448 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-452-links.snip.markdown
+++ b/soups/weeklinks/week-452-links.snip.markdown
@@ -37,3 +37,4 @@ This account of finding the the shortest distance between two houses with the sa
 :author: james-mead
 :page_title: Week 452 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-454-links.snip.markdown
+++ b/soups/weeklinks/week-454-links.snip.markdown
@@ -58,3 +58,4 @@ We became interested in the [Credit Union Expansion Project][cuep] while investi
 :author: james-mead
 :page_title: Week 454 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-458-links.snip.markdown
+++ b/soups/weeklinks/week-458-links.snip.markdown
@@ -40,3 +40,4 @@ This project captures AIS messages broadcast by passing ships to obtain identity
 :author: james-mead
 :page_title: Week 458 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-460-links.snip.markdown
+++ b/soups/weeklinks/week-460-links.snip.markdown
@@ -33,3 +33,4 @@ This open-source realtime P2P collaborative editor looks really promising, espec
 :author: chris-lowis
 :page_title: Week 460 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-462-links.snip.markdown
+++ b/soups/weeklinks/week-462-links.snip.markdown
@@ -21,3 +21,4 @@ Some useful thoughts from Harry at [Outlandish](https://outlandish.com) ahead of
 :author: chris-lowis
 :page_title: Week 462 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-470-links.snip.markdown
+++ b/soups/weeklinks/week-470-links.snip.markdown
@@ -85,3 +85,4 @@ I was aware of the [`ffi` gem][ffi-gem], but I didn't realise that Ruby's standa
 :author: james-mead
 :page_title: Week 470 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-476-links.snip.markdown
+++ b/soups/weeklinks/week-476-links.snip.markdown
@@ -51,3 +51,4 @@ Our friends at Webarchitects are celebrating 20 years in operation as a co-opera
 :author: james-mead
 :page_title: Week 476 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-478-links.snip.markdown
+++ b/soups/weeklinks/week-478-links.snip.markdown
@@ -42,3 +42,4 @@ We were recently asked to agree to GDPR-related changes in the contract for the 
 :author: chris-roos
 :page_title: Week 478 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-491-links.snip.markdown
+++ b/soups/weeklinks/week-491-links.snip.markdown
@@ -55,3 +55,4 @@ This is a crazy, but fun, project that allows you to make your robot available o
 :author: james-mead
 :page_title: Week 491 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-494-links.snip.markdown
+++ b/soups/weeklinks/week-494-links.snip.markdown
@@ -33,3 +33,4 @@ Our very own Chris Lowis features in this Wired article about [CoTech][co-tech].
 :author: chris-roos
 :page_title: Week 494 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-498-links.snip.markdown
+++ b/soups/weeklinks/week-498-links.snip.markdown
@@ -29,3 +29,4 @@ French game studio Motion Twin talk about their co-operative structure and their
 :author: chris-lowis
 :page_title: Week 498 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-502-links.snip.markdown
+++ b/soups/weeklinks/week-502-links.snip.markdown
@@ -35,3 +35,4 @@ An interesting panel discussion with Mike Bracken, Martha-Lane Fox, Ian Watmore 
 :author: james-mead
 :page_title: Week 502 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-504-links.snip.markdown
+++ b/soups/weeklinks/week-504-links.snip.markdown
@@ -55,3 +55,4 @@ I think it's fair to say that we collectively struggle to write weeknotes so I e
 :author: chris-roos
 :page_title: Week 504 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-506-links.snip.markdown
+++ b/soups/weeklinks/week-506-links.snip.markdown
@@ -39,3 +39,4 @@ I do think it's a bad idea to schedule technical tasks, but I'm not totally conv
 :author: james-mead
 :page_title: Week 506 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-508-links.snip.markdown
+++ b/soups/weeklinks/week-508-links.snip.markdown
@@ -57,3 +57,4 @@ I was very pleasantly surprised when I was prompted to use my fingerprint to con
 :author: chris-roos
 :page_title: Week 508 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeklinks/week-530-links.snip.markdown
+++ b/soups/weeklinks/week-530-links.snip.markdown
@@ -61,3 +61,4 @@ This is great! I'm all for making it as easy as possible for people to see how t
 :author: james-mead
 :page_title: Week 530 - Interesting links
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-148.snip.markdown
+++ b/soups/weeknotes/week-148.snip.markdown
@@ -63,3 +63,4 @@ JASE.
 :created_at: 2011-11-18 15:43:00 +01:00
 :updated_at: 2022-04-22 17:58:00 +01:00
 :page_title: Week 148
+:erb: true

--- a/soups/weeknotes/week-153.snip.markdown
+++ b/soups/weeknotes/week-153.snip.markdown
@@ -102,3 +102,4 @@ Until next time, blog friends.
 :created_at: 2011-12-23 11:15:00 +00:00
 :updated_at: 2011-12-23 11:15:00 +00:00
 :page_title: Week 153
+:erb: true

--- a/soups/weeknotes/week-163.snip.markdown
+++ b/soups/weeknotes/week-163.snip.markdown
@@ -49,3 +49,4 @@ Auf wiedersehen.
 :created_at: 2012-03-02 11:22:00 +01:00
 :updated_at: 2012-03-02 11:22:00 +01:00
 :page_title: Week 163
+:erb: true

--- a/soups/weeknotes/week-165.snip.markdown
+++ b/soups/weeknotes/week-165.snip.markdown
@@ -87,3 +87,4 @@ Until next time, blog-friends,
 :created_at: 2012-03-17 12:23:00 +01:00
 :updated_at: 2012-03-17 12:23:00 +01:00
 :page_title: Week 165
+:erb: true

--- a/soups/weeknotes/week-168.snip.markdown
+++ b/soups/weeknotes/week-168.snip.markdown
@@ -101,3 +101,4 @@ That's all, folks.
 :created_at: 2012-04-05 13:32:00 +01:00
 :updated_at: 2012-04-05 13:32:00 +01:00
 :page_title: Week 168
+:erb: true

--- a/soups/weeknotes/week-169.snip.markdown
+++ b/soups/weeknotes/week-169.snip.markdown
@@ -80,3 +80,4 @@ Anyway, that was the week that was. Onwards to Week 170!
 :created_at: 2012-04-16 11:49:00 +01:00
 :updated_at: 2012-04-16 11:49:00 +01:00
 :page_title: Week 169
+:erb: true

--- a/soups/weeknotes/week-171.snip.markdown
+++ b/soups/weeknotes/week-171.snip.markdown
@@ -41,3 +41,4 @@ Anyway, that's it for another week.  These weeknotes were brought to you by the 
 :created_at: 2012-04-30 10:49:00 +01:00
 :updated_at: 2012-04-30 10:49:00 +01:00
 :page_title: Week 171 - Focus Grasshopper
+:erb: true

--- a/soups/weeknotes/week-172.snip.markdown
+++ b/soups/weeknotes/week-172.snip.markdown
@@ -84,3 +84,4 @@ Adios compadre,
 :created_at: 2012-05-03 10:49:00 +01:00
 :updated_at: 2012-05-03 10:49:00 +01:00
 :page_title: Week 172
+:erb: true

--- a/soups/weeknotes/week-187.snip.markdown
+++ b/soups/weeknotes/week-187.snip.markdown
@@ -109,3 +109,4 @@ Until next time,
 :created_at: 2012-08-18 02:01:00 +01:00
 :updated_at: 2012-08-18 02:01:00 +01:00
 :page_title: "Week 187"
+:erb: true

--- a/soups/weeknotes/week-193.snip.markdown
+++ b/soups/weeknotes/week-193.snip.markdown
@@ -90,3 +90,4 @@ Adiós y buena suerte, amigos!
 :created_at: 2012-09-28 17:00:00 +01:00
 :updated_at: 2012-09-28 17:00:00 +01:00
 :page_title: Week 193
+:erb: true

--- a/soups/weeknotes/week-196.snip.markdown
+++ b/soups/weeknotes/week-196.snip.markdown
@@ -58,3 +58,4 @@ We're back up to full strength next week, so hopefully we'll be able to get a fi
 :created_at: 2012-10-20 10:30:00 +01:00
 :updated_at: 2012-10-20 10:30:00 +01:00
 :page_title: Week 196
+:erb: true

--- a/soups/weeknotes/week-200.snip.markdown
+++ b/soups/weeknotes/week-200.snip.markdown
@@ -52,3 +52,4 @@ Hagoonea'
 :created_at: 2012-11-18 21:30:00 +00:00
 :updated_at: 2012-11-18 21:30:00 +00:00
 :page_title: Week 200
+:erb: true

--- a/soups/weeknotes/week-210.snip.markdown
+++ b/soups/weeknotes/week-210.snip.markdown
@@ -87,3 +87,4 @@ Until next time,
 :created_at: 2013-01-25 14:46:00 +00:00
 :updated_at: 2013-01-25 14:46:00 +00:00
 :page_title: Week 210
+:erb: true

--- a/soups/weeknotes/week-224.snip.markdown
+++ b/soups/weeknotes/week-224.snip.markdown
@@ -54,3 +54,4 @@ Until next time.
 :updated_at: 2013-05-03 16:00:00 +01:00
 :page_title: Week 224
 
+:erb: true

--- a/soups/weeknotes/week-236.snip.markdown
+++ b/soups/weeknotes/week-236.snip.markdown
@@ -31,3 +31,4 @@ So that's that. See you next time,
 :created_at: 2013-07-25 10:00:00 +06:00
 :updated_at: 2013-07-25 10:00:00 +06:00
 :page_title: Week 236
+:erb: true

--- a/soups/weeknotes/week-244.snip.markdown
+++ b/soups/weeknotes/week-244.snip.markdown
@@ -37,3 +37,4 @@ Anyway, that's it for now. Have a great weekend!
 :created_at: 2013-09-20 16:00:00 +01:00
 :updated_at: 2013-09-20 16:00:00 +01:00
 :page_title: Week 244
+:erb: true

--- a/soups/weeknotes/week-262.snip.markdown
+++ b/soups/weeknotes/week-262.snip.markdown
@@ -23,3 +23,4 @@ Friday was FutureLearn's last day in their Open University home before moving to
 :created_at: 2014-01-29 08:00:00 +00:00
 :updated_at: 2014-01-29 08:00:00 +00:00
 :page_title: Week 262
+:erb: true

--- a/soups/weeknotes/week-264.snip.markdown
+++ b/soups/weeknotes/week-264.snip.markdown
@@ -27,3 +27,4 @@ All that's left is to show you the [double rainbow](http://www.youtube.com/watch
 :created_at: 2014-02-10 16:30:00 +00:00
 :updated_at: 2014-02-10 16:30:00 +00:00
 :page_title: Week 264 - Double Rainbow!
+:erb: true

--- a/soups/weeknotes/week-266.snip.markdown
+++ b/soups/weeknotes/week-266.snip.markdown
@@ -40,3 +40,4 @@ Anyways, I think that'll do us for week 266. Until next time, everybody peeps.
 :created_at: 2014-02-24 13:30:00 +00:00
 :updated_at: 2014-02-24 13:30:00 +00:00
 :page_title: Week 266
+:erb: true

--- a/soups/weeknotes/week-292.snip.markdown
+++ b/soups/weeknotes/week-292.snip.markdown
@@ -69,3 +69,4 @@ Until next time.
 :created_at: 2014-08-27 15:40:00 +01:00
 :updated_at: 2014-08-27 15:40:00 +01:00
 :page_title: Week 292
+:erb: true

--- a/soups/weeknotes/week-319.snip.markdown
+++ b/soups/weeknotes/week-319.snip.markdown
@@ -104,3 +104,4 @@ Anyway, until next time.
 :created_at: 2015-03-04 12:09:00 +01:00
 :updated_at: 2015-03-04 12:09:00 +01:00
 :page_title: Week 319
+:erb: true

--- a/soups/weeknotes/week-327.snip.markdown
+++ b/soups/weeknotes/week-327.snip.markdown
@@ -53,3 +53,4 @@ Not able to top that, I'll say cheerio for now. I hope y'all have a good weekend
 :created_at: 2015-05-01 10:50:00 +01:00
 :updated_at: 2015-05-01 12:25:00 +01:00
 :page_title: Week 327
+:erb: true

--- a/soups/weeknotes/week-431.snip.markdown
+++ b/soups/weeknotes/week-431.snip.markdown
@@ -87,3 +87,4 @@ pace.
 :author: chris-lowis
 :page_title: Week 431
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-437.snip.markdown
+++ b/soups/weeknotes/week-437.snip.markdown
@@ -94,3 +94,4 @@ Have a great weekend!
 :author: chris-lowis
 :page_title: Week 437
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-462.snip.markdown
+++ b/soups/weeknotes/week-462.snip.markdown
@@ -27,3 +27,4 @@ Anyway, until next time.
 :author: james-mead
 :page_title: Week 462
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-463.snip.markdown
+++ b/soups/weeknotes/week-463.snip.markdown
@@ -29,3 +29,4 @@ That's all for now. Until next time.
 :author: chris-roos
 :page_title: Week 463
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-525.snip.markdown
+++ b/soups/weeknotes/week-525.snip.markdown
@@ -36,3 +36,4 @@ Have a great weekend!
 :author: chris-lowis
 :page_title: Week 525
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-531.snip.markdown
+++ b/soups/weeknotes/week-531.snip.markdown
@@ -66,3 +66,4 @@ Until next time!
 :author: james-mead
 :page_title: Week 531
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-534.snip.markdown
+++ b/soups/weeknotes/week-534.snip.markdown
@@ -65,3 +65,4 @@ Until next time.
 :author: chris-roos
 :page_title: Week 534
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-536.snip.markdown
+++ b/soups/weeknotes/week-536.snip.markdown
@@ -73,3 +73,4 @@ That's all, folks!
 :author: james-mead
 :page_title: Week 536
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-547.snip.markdown
+++ b/soups/weeknotes/week-547.snip.markdown
@@ -114,3 +114,4 @@ Until next time,
 :author: james-mead
 :page_title: Weeks 545-7
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-555.snip.markdown
+++ b/soups/weeknotes/week-555.snip.markdown
@@ -48,3 +48,4 @@ That's about it for now. Until next time.
 :author: chris-roos
 :page_title: Weeks 554 and 555
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-818.snip.markdown
+++ b/soups/weeknotes/week-818.snip.markdown
@@ -40,3 +40,4 @@ We spent a while discussing whether we could provide Mission Patches as [Open Ba
 :author: chris-roos
 :page_title: Week 818
 :extension: markdown
+:erb: true

--- a/soups/weeknotes/week-824.snip.markdown
+++ b/soups/weeknotes/week-824.snip.markdown
@@ -70,3 +70,4 @@ Chris has taken the lead on business development recently, contacting various pe
 :author: chris-roos
 :page_title: Week 824
 :extension: markdown
+:erb: true

--- a/soups/work.snip.html
+++ b/soups/work.snip.html
@@ -20,3 +20,4 @@
 :created_at: 2010-07-21 13:12:26 +0100
 :created_sha: 3d10ae1f1a58883519a8bd92a44eb7f454a12ad5
 :updated_at: 2017-08-19 10:50:48 +0100
+:erb: true

--- a/spec/lib/snip_renderer_spec.rb
+++ b/spec/lib/snip_renderer_spec.rb
@@ -4,29 +4,45 @@ RSpec.describe SnipRenderer do
   describe '#render' do
     context 'when the snip is markdown' do
       it 'returns the markdown rendered as html' do
-        snip = double(content: '# Hello', extension: 'markdown')
+        snip = double(content: '# Hello', extension: 'markdown', erb: false)
         rendered = SnipRenderer.new.render(snip, binding)
         expect(rendered).to eq("<h1 id=\"hello\">Hello</h1>\n")
       end
 
       it 'uses the GitHub Flavoured Markdown renderer' do
-        snip = double(content: 'content', extension: 'markdown')
+        snip = double(content: 'content', extension: 'markdown', erb: false)
         expect(Kramdown::Document).to receive(:new).with('content', include(input: 'GFM')).and_call_original
         SnipRenderer.new.render(snip, binding)
       end
 
       it 'uses rouge for syntax highlighting in markdown content' do
-        snip = double(content: 'content', extension: 'markdown')
+        snip = double(content: 'content', extension: 'markdown', erb: false)
         expect(Kramdown::Document).to receive(:new).with('content', include(syntax_highlighter: 'rouge')).and_call_original
         SnipRenderer.new.render(snip, binding)
+      end
+
+      context 'and ERB is enabled' do
+        it 'returns the ERB & markdown rendered as html' do
+          snip = double(content: '# <%= "Hello" %>', extension: 'markdown', erb: true)
+          rendered = SnipRenderer.new.render(snip, binding)
+          expect(rendered).to eq("<h1 id=\"hello\">Hello</h1>\n")
+        end
       end
     end
 
     context 'when the snip is not markdown' do
       it 'returns the unmodified content' do
-        snip = double(content: '# Hello', extension: 'not-markdown')
+        snip = double(content: '# Hello', extension: 'not-markdown', erb: false)
         rendered = SnipRenderer.new.render(snip, binding)
         expect(rendered).to eq('# Hello')
+      end
+
+      context 'and ERB is enabled' do
+        it 'returns the ERB rendered' do
+          snip = double(content: '# <%= "Hello" %>', extension: 'not-markdown', erb: true)
+          rendered = SnipRenderer.new.render(snip, binding)
+          expect(rendered).to eq('# Hello')
+        end
       end
     end
   end


### PR DESCRIPTION
This is an attempt to solve the problem that @chrisroos has run into in #508 where he wants to display raw ERB tags in an blog post.

Only the minority of pages need ERB rendering and so this PR requires such pages to explicitly enable it using an `erb` attribute...

```
:erb: true
```

I used a shell script using `ripgrep` to append such an attribute to all files containing an opening ERB tag. I'm fairly confident this covers all the relevant pages, but I might have missed some!

I did consider trying to use multiple extensions in the filename like Rails does for views, but unfortunately the `soup` gem doesn't capture anything other than the final extension.