### PR TITLE
Disable hard_wrap in kramdown-parser-gfm

### DIFF
--- a/lib/snip_renderer.rb
+++ b/lib/snip_renderer.rb
@@ -9,7 +9,7 @@ class SnipRenderer
       when 'erb'
         ERB.new(content).result(context)
       when 'markdown'
-        Kramdown::Document.new(content, input: 'GFM', syntax_highlighter: 'rouge').to_html
+        Kramdown::Document.new(content, input: 'GFM', syntax_highlighter: 'rouge', hard_wrap: false).to_html
       else
         content
       end

--- a/spec/lib/snip_renderer_spec.rb
+++ b/spec/lib/snip_renderer_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe SnipRenderer do
         SnipRenderer.new.render(snip, binding)
       end
 
+      it 'does not hard wrap markdown content to preserve compatibility with kramdown renderer' do
+        snip = double(content: 'content', extension: 'markdown', erb: false)
+        expect(Kramdown::Document).to receive(:new).with('content', include(hard_wrap: false)).and_call_original
+        SnipRenderer.new.render(snip, binding)
+      end
+
       context 'and ERB is enabled' do
         it 'returns the ERB & markdown rendered as html' do
           snip = double(content: '# <%= "Hello" %>', extension: 'markdown', erb: true)


### PR DESCRIPTION
The `hard_wrap` option is [set to true by default][1] which results in newlines within paragraphs being rendered as `<br/>` in HTML. This was causing a number of our pages (e.g. week-826) to be rendered differently since switching from the default kramdown renderer to the GFM renderer in 244422546d800f2367045a1429207dd07819f8a4.

I used the `rake spec:regression:artefacts` task to compare the rendered site with and without this option, and with the default kramdown renderer and I'm happy that the behaviour in this commit is closer to what we had originally. The only obvious change I can now see between the default kramdown renderer and the GFM renderer is that some automatically generated heading IDs are different but I'm happy to live with that.

The screenshots below show the difference in setting the `hard_wrap` option:

## With `hard_wrap` set to true

![Screenshot 2025-03-14 at 12-35-37 Week 826 — Go Free Range](https://github.com/user-attachments/assets/5cd5b479-76a2-43f1-a044-2441ff332920)

## With `hard_wrap` set to false

![Screenshot 2025-03-14 at 12-35-44 Week 826 — Go Free Range](https://github.com/user-attachments/assets/7664bce3-e64f-43b8-9186-7a4ac42a5c5d)


[1]: https://github.com/kramdown/parser-gfm?tab=readme-ov-file